### PR TITLE
[codex] Implement Wirdle v2 M1 post-game coach

### DIFF
--- a/wirdle/src/coach.rs
+++ b/wirdle/src/coach.rs
@@ -1,0 +1,970 @@
+use crate::feedback::LetterStatus;
+use crate::filter::{GuessInput, filter_candidates, is_candidate_consistent};
+use crate::rank::evaluate_information_guess;
+use crate::rank::{InformationGuess, rank_likely_answers};
+use crate::solver::{PastSolutionPolicy, Solver};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CoachIntent {
+    PostGameReview,
+    EasyHint,
+}
+
+impl CoachIntent {
+    pub fn parse(input: &str) -> Option<Self> {
+        match input {
+            "post_game_review" => Some(Self::PostGameReview),
+            "easy_hint" => Some(Self::EasyHint),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PostGameReview => "post_game_review",
+            Self::EasyHint => "easy_hint",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct CoachRequest {
+    pub intent: CoachIntent,
+    pub guesses: Vec<GuessInput>,
+    pub hard_mode: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum BoardState {
+    InProgress,
+    Solved { turn: usize },
+    Lost,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum InformationBucket {
+    Low,
+    Modest,
+    Solid,
+    Sharp,
+}
+
+impl InformationBucket {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::Modest => "modest",
+            Self::Solid => "solid",
+            Self::Sharp => "sharp",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ConstraintDiscipline {
+    Clean,
+    Miss,
+}
+
+impl ConstraintDiscipline {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Clean => "clean",
+            Self::Miss => "miss",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MoveType {
+    Probe,
+    SolveAttempt,
+    ForcedSolve,
+    ConstraintMiss,
+}
+
+impl MoveType {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Probe => "probe",
+            Self::SolveAttempt => "solve_attempt",
+            Self::ForcedSolve => "forced_solve",
+            Self::ConstraintMiss => "constraint_miss",
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Stage {
+    Opener,
+    Middle,
+    Endgame,
+    Final,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum TrapRisk {
+    Low,
+    Moderate,
+    High,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum DuplicateLetterNote {
+    None,
+    Useful,
+    Risky,
+}
+
+#[derive(Clone, Debug)]
+pub struct BoardAnalysis {
+    pub state: BoardState,
+    pub turns: Vec<TurnAnalysis>,
+    pub final_remaining_candidates: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct TurnAnalysis {
+    pub turn_index: usize,
+    pub statuses: [LetterStatus; 5],
+    pub candidates_before: usize,
+    pub candidates_after: usize,
+    pub information: InformationGuess,
+    pub information_bucket: InformationBucket,
+    pub constraint_discipline: ConstraintDiscipline,
+    pub constraint_note: Option<String>,
+    pub move_type: MoveType,
+    stage: Stage,
+    trap_risk: TrapRisk,
+    duplicate_letter_note: DuplicateLetterNote,
+    vowel_count: usize,
+    solved_on_turn: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct CoachResponse {
+    pub intent: CoachIntent,
+    pub board: BoardSummary,
+    pub post_game: Option<PostGameReport>,
+    pub share: Option<ShareOutput>,
+}
+
+#[derive(Clone, Debug)]
+pub struct BoardSummary {
+    pub state: BoardState,
+    pub turns: usize,
+    pub remaining_candidates: usize,
+}
+
+#[derive(Clone, Debug)]
+pub struct PostGameReport {
+    pub grades: Vec<String>,
+    pub turns: Vec<TurnReview>,
+    pub summary: GameSummary,
+}
+
+#[derive(Clone, Debug)]
+pub struct TurnReview {
+    pub turn: usize,
+    pub label: String,
+    pub grade: String,
+    pub score: i32,
+    pub move_type: MoveType,
+    pub information: InformationBucket,
+    pub constraint_discipline: ConstraintDiscipline,
+    pub did_well: String,
+    pub missed: String,
+    pub summary: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct GameSummary {
+    pub best_move_turn: usize,
+    pub most_questionable_turn: usize,
+    pub biggest_information_gain_turn: usize,
+    pub best_recovery_turn: Option<usize>,
+    pub missed_opportunity: Option<String>,
+    pub lesson: String,
+}
+
+#[derive(Clone, Debug)]
+pub struct ShareOutput {
+    pub text: String,
+    pub contains_guess_words: bool,
+}
+
+#[derive(Clone, Debug)]
+pub struct CoachError {
+    pub code: &'static str,
+    pub message: String,
+}
+
+impl CoachError {
+    pub fn new(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            message: message.into(),
+        }
+    }
+}
+
+pub fn coach(solver: &Solver, request: &CoachRequest) -> Result<CoachResponse, CoachError> {
+    match request.intent {
+        CoachIntent::PostGameReview => post_game_review(solver, request),
+        CoachIntent::EasyHint => Err(CoachError::new(
+            "unsupported_intent",
+            "Easy Mode hints are not implemented in Milestone 1.",
+        )),
+    }
+}
+
+pub fn analyze_board(
+    solver: &Solver,
+    guesses: &[GuessInput],
+    hard_mode: bool,
+) -> Result<BoardAnalysis, CoachError> {
+    let mut turns = Vec::with_capacity(guesses.len());
+    let mut prior = Vec::new();
+    let mut solved_turn = None;
+    let mut final_remaining_candidates = solver.lexicon().candidate_solutions.len();
+
+    for (idx, guess) in guesses.iter().enumerate() {
+        if solved_turn.is_some() {
+            return Err(CoachError::new(
+                "invalid_request",
+                "Rows after a solved Wordle row are not valid game data.",
+            ));
+        }
+
+        let candidates_before = filter_candidates(&solver.lexicon().candidate_solutions, &prior);
+        if candidates_before.is_empty() {
+            return Err(board_inconsistent());
+        }
+
+        let likely_answers = rank_likely_answers(
+            &candidates_before,
+            solver.past(),
+            &PastSolutionPolicy::default(),
+            &solver.lexicon().overrides,
+        );
+        let information = evaluate_information_guess(
+            guess.word,
+            &candidates_before,
+            &likely_answers,
+            solver.past(),
+        );
+        let mut with_current = prior.clone();
+        with_current.push(guess.clone());
+        let candidates_after =
+            filter_candidates(&solver.lexicon().candidate_solutions, &with_current);
+        if candidates_after.is_empty() {
+            return Err(board_inconsistent());
+        }
+
+        let respects_known_info = prior.is_empty() || is_candidate_consistent(guess.word, &prior);
+        let constraint_note = constraint_note(guess, &prior, hard_mode, respects_known_info);
+        let solved_on_turn = guess
+            .statuses
+            .iter()
+            .all(|status| *status == LetterStatus::Correct);
+        if solved_on_turn {
+            solved_turn = Some(idx + 1);
+        }
+
+        final_remaining_candidates = candidates_after.len();
+        turns.push(TurnAnalysis {
+            turn_index: idx,
+            statuses: guess.statuses,
+            candidates_before: candidates_before.len(),
+            candidates_after: candidates_after.len(),
+            information,
+            information_bucket: information_bucket(candidates_before.len(), candidates_after.len()),
+            constraint_discipline: if respects_known_info {
+                ConstraintDiscipline::Clean
+            } else {
+                ConstraintDiscipline::Miss
+            },
+            constraint_note,
+            move_type: move_type(
+                respects_known_info,
+                candidates_before.len(),
+                idx,
+                information_bucket(candidates_before.len(), candidates_after.len()),
+                guess.word,
+                &candidates_before,
+            ),
+            stage: stage(idx),
+            trap_risk: trap_risk(&candidates_before),
+            duplicate_letter_note: duplicate_letter_note(guess),
+            vowel_count: vowel_count(guess.word),
+            solved_on_turn,
+        });
+        prior = with_current;
+    }
+
+    let state = if let Some(turn) = solved_turn {
+        BoardState::Solved { turn }
+    } else if guesses.len() == 6 {
+        BoardState::Lost
+    } else {
+        BoardState::InProgress
+    };
+
+    Ok(BoardAnalysis {
+        state,
+        turns,
+        final_remaining_candidates,
+    })
+}
+
+fn post_game_review(solver: &Solver, request: &CoachRequest) -> Result<CoachResponse, CoachError> {
+    let analysis = analyze_board(solver, &request.guesses, request.hard_mode)?;
+    if analysis.state == BoardState::InProgress {
+        return Err(CoachError::new(
+            "board_incomplete",
+            "Finish the Wordle board before reviewing your game.",
+        ));
+    }
+
+    let report = build_post_game_report(&analysis);
+    let share_text = build_share_text(&analysis, &report);
+    let contains_guess_words = request
+        .guesses
+        .iter()
+        .any(|guess| share_text.to_lowercase().contains(guess.word.as_str()));
+
+    Ok(CoachResponse {
+        intent: request.intent,
+        board: BoardSummary {
+            state: analysis.state.clone(),
+            turns: analysis.turns.len(),
+            remaining_candidates: analysis.final_remaining_candidates,
+        },
+        post_game: Some(report),
+        share: Some(ShareOutput {
+            text: share_text,
+            contains_guess_words,
+        }),
+    })
+}
+
+fn build_post_game_report(analysis: &BoardAnalysis) -> PostGameReport {
+    let turns: Vec<TurnReview> = analysis.turns.iter().map(review_turn).collect();
+    let grades = turns.iter().map(|turn| turn.grade.clone()).collect();
+    let summary = game_summary(&turns);
+    PostGameReport {
+        grades,
+        turns,
+        summary,
+    }
+}
+
+fn review_turn(turn: &TurnAnalysis) -> TurnReview {
+    let label = turn_label(turn).to_string();
+    let score = turn_score(turn);
+    let grade = grade(score).to_string();
+    let did_well = did_well(turn, &label);
+    let missed = missed(turn);
+    let summary = turn_summary(turn, &label);
+
+    TurnReview {
+        turn: turn.turn_index + 1,
+        label,
+        grade,
+        score,
+        move_type: turn.move_type,
+        information: turn.information_bucket,
+        constraint_discipline: turn.constraint_discipline,
+        did_well,
+        missed,
+        summary,
+    }
+}
+
+fn game_summary(turns: &[TurnReview]) -> GameSummary {
+    let best_move = turns
+        .iter()
+        .max_by_key(|turn| (turn.score, turn.information, turn.turn))
+        .expect("post-game report has at least one turn");
+    let most_questionable = turns
+        .iter()
+        .min_by_key(|turn| {
+            let forced_final_offset = if turn.move_type == MoveType::ForcedSolve {
+                20
+            } else {
+                0
+            };
+            (turn.score + forced_final_offset, turn.turn)
+        })
+        .expect("post-game report has at least one turn");
+    let biggest_information = turns
+        .iter()
+        .max_by_key(|turn| (turn.information, turn.score, turn.turn))
+        .expect("post-game report has at least one turn");
+    let best_recovery_turn = turns.windows(2).find_map(|pair| {
+        let weak = pair[0].score <= 68;
+        let strong_after = pair[1].score >= 83;
+        (weak && strong_after).then_some(pair[1].turn)
+    });
+    let missed_opportunity = (most_questionable.score <= 72).then(|| {
+        format!(
+            "Turn {} could have focused more on {}.",
+            most_questionable.turn,
+            opportunity_phrase(most_questionable)
+        )
+    });
+    let lesson = lesson(turns);
+
+    GameSummary {
+        best_move_turn: best_move.turn,
+        most_questionable_turn: most_questionable.turn,
+        biggest_information_gain_turn: biggest_information.turn,
+        best_recovery_turn,
+        missed_opportunity,
+        lesson,
+    }
+}
+
+fn opportunity_phrase(turn: &TurnReview) -> &'static str {
+    if turn.constraint_discipline == ConstraintDiscipline::Miss {
+        "using the clues already earned"
+    } else if turn.move_type == MoveType::SolveAttempt
+        && turn.information <= InformationBucket::Modest
+    {
+        "splitting the remaining pattern before guessing one answer"
+    } else if turn.information <= InformationBucket::Low {
+        "testing fresh information"
+    } else {
+        "the main uncertainty in the pattern"
+    }
+}
+
+fn lesson(turns: &[TurnReview]) -> String {
+    if turns
+        .iter()
+        .any(|turn| turn.constraint_discipline == ConstraintDiscipline::Miss)
+    {
+        return "Carry every green and yellow clue into the next turn before choosing a word."
+            .to_string();
+    }
+    if turns
+        .iter()
+        .filter(|turn| turn.information <= InformationBucket::Low)
+        .count()
+        >= 2
+    {
+        return "When the board stalls, spend a turn separating the pattern instead of repeating the same information.".to_string();
+    }
+    if turns.iter().any(|turn| turn.label == "Trap Breaker") {
+        return "When a word family forms, test the changing position before guessing one-by-one."
+            .to_string();
+    }
+    if turns.iter().any(|turn| {
+        turn.move_type == MoveType::SolveAttempt && turn.information <= InformationBucket::Modest
+    }) {
+        return "Before a direct solve, check whether several similar answers are still alive."
+            .to_string();
+    }
+    "Keep matching the purpose of the guess to the stage of the game: broad early, answer-shaped late."
+        .to_string()
+}
+
+fn build_share_text(analysis: &BoardAnalysis, report: &PostGameReport) -> String {
+    let result = match analysis.state {
+        BoardState::Solved { turn } => format!("Wordle {turn}/6"),
+        BoardState::Lost => "Wordle X/6".to_string(),
+        BoardState::InProgress => "Wordle ?/6".to_string(),
+    };
+    let grid = analysis
+        .turns
+        .iter()
+        .map(|turn| status_grid_row(&turn.statuses))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let grades = report.grades.join(" / ");
+    let best = report.summary.best_move_turn;
+    let lesson = &report.summary.lesson;
+
+    format!(
+        "{result}\n{grid}\n\nWirdle: Post Game Mode\nGrades: {grades}\nCoach: best move was turn {best}. Lesson: {lesson}\n\nwirdle.onrender.com"
+    )
+}
+
+pub fn status_grid_row(statuses: &[LetterStatus; 5]) -> String {
+    statuses
+        .iter()
+        .map(|status| match status {
+            LetterStatus::Absent => "⬛",
+            LetterStatus::Present => "🟨",
+            LetterStatus::Correct => "🟩",
+        })
+        .collect()
+}
+
+fn information_bucket(before: usize, after: usize) -> InformationBucket {
+    if before <= 1 {
+        return InformationBucket::Sharp;
+    }
+    let reduction = 1.0 - (after as f64 / before as f64);
+    if after <= 1 || reduction >= 0.85 {
+        InformationBucket::Sharp
+    } else if reduction >= 0.55 {
+        InformationBucket::Solid
+    } else if reduction >= 0.25 {
+        InformationBucket::Modest
+    } else {
+        InformationBucket::Low
+    }
+}
+
+fn move_type(
+    respects_known_info: bool,
+    candidates_before: usize,
+    turn_index: usize,
+    information_bucket: InformationBucket,
+    guess: crate::word::Word,
+    candidates: &[crate::word::Word],
+) -> MoveType {
+    if !respects_known_info {
+        return MoveType::ConstraintMiss;
+    }
+    let is_possible_answer = candidates.contains(&guess);
+    if is_possible_answer && (candidates_before <= 3 || turn_index >= 4) {
+        MoveType::ForcedSolve
+    } else if is_possible_answer {
+        MoveType::SolveAttempt
+    } else if information_bucket == InformationBucket::Low && turn_index >= 4 {
+        MoveType::ConstraintMiss
+    } else {
+        MoveType::Probe
+    }
+}
+
+fn stage(turn_index: usize) -> Stage {
+    match turn_index {
+        0 => Stage::Opener,
+        5 => Stage::Final,
+        3 | 4 => Stage::Endgame,
+        _ => Stage::Middle,
+    }
+}
+
+fn trap_risk(candidates: &[crate::word::Word]) -> TrapRisk {
+    if candidates.len() <= 4 {
+        return TrapRisk::High;
+    }
+    if candidates.len() <= 10 && tight_family(candidates) {
+        return TrapRisk::High;
+    }
+    if candidates.len() <= 16 {
+        return TrapRisk::Moderate;
+    }
+    TrapRisk::Low
+}
+
+fn tight_family(candidates: &[crate::word::Word]) -> bool {
+    (0..5).any(|skip| {
+        let first = candidates.first().map(|word| {
+            word.0
+                .iter()
+                .enumerate()
+                .filter_map(|(idx, letter)| (idx != skip).then_some(*letter))
+                .collect::<Vec<_>>()
+        });
+        first.is_some_and(|pattern| {
+            candidates.iter().all(|word| {
+                word.0
+                    .iter()
+                    .enumerate()
+                    .filter_map(|(idx, letter)| (idx != skip).then_some(*letter))
+                    .collect::<Vec<_>>()
+                    == pattern
+            })
+        })
+    })
+}
+
+fn duplicate_letter_note(guess: &GuessInput) -> DuplicateLetterNote {
+    let mut counts = [0u8; 26];
+    for letter in guess.word.letters() {
+        counts[letter] += 1;
+    }
+    let repeated = counts.iter().any(|count| *count > 1);
+    if !repeated {
+        return DuplicateLetterNote::None;
+    }
+    let useful = guess
+        .word
+        .letters()
+        .iter()
+        .enumerate()
+        .any(|(idx, letter)| counts[*letter] > 1 && guess.statuses[idx] != LetterStatus::Absent);
+    if useful {
+        DuplicateLetterNote::Useful
+    } else {
+        DuplicateLetterNote::Risky
+    }
+}
+
+fn constraint_note(
+    guess: &GuessInput,
+    prior: &[GuessInput],
+    hard_mode: bool,
+    respects_known_info: bool,
+) -> Option<String> {
+    if respects_known_info {
+        return None;
+    }
+
+    let mut green_positions = Vec::new();
+    let mut yellow_positions = Vec::new();
+    let mut confirmed_counts = [0u8; 26];
+    let mut absent_letters = [false; 26];
+    let mut seen_confirmed = [false; 26];
+
+    for prior_guess in prior {
+        for (idx, status) in prior_guess.statuses.iter().enumerate() {
+            let letter = usize::from(prior_guess.word.0[idx] - b'a');
+            match status {
+                LetterStatus::Correct => {
+                    green_positions.push((idx, prior_guess.word.0[idx]));
+                    confirmed_counts[letter] = confirmed_counts[letter].max(1);
+                    seen_confirmed[letter] = true;
+                }
+                LetterStatus::Present => {
+                    yellow_positions.push((idx, prior_guess.word.0[idx]));
+                    confirmed_counts[letter] = confirmed_counts[letter].max(1);
+                    seen_confirmed[letter] = true;
+                }
+                LetterStatus::Absent => {
+                    if !seen_confirmed[letter] {
+                        absent_letters[letter] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if green_positions
+        .iter()
+        .any(|(idx, letter)| guess.word.0[*idx] != *letter)
+    {
+        return Some("It moved away from a confirmed green position.".to_string());
+    }
+    if yellow_positions
+        .iter()
+        .any(|(idx, letter)| guess.word.0[*idx] == *letter)
+    {
+        return Some(
+            "It left a known yellow letter in a place that had already been ruled out.".to_string(),
+        );
+    }
+    let guess_counts = guess
+        .word
+        .letters()
+        .iter()
+        .fold([0u8; 26], |mut counts, letter| {
+            counts[*letter] += 1;
+            counts
+        });
+    if confirmed_counts
+        .iter()
+        .enumerate()
+        .any(|(idx, count)| *count > 0 && guess_counts[idx] < *count)
+    {
+        return Some(
+            "It dropped a letter that earlier feedback had already confirmed.".to_string(),
+        );
+    }
+    if guess
+        .word
+        .letters()
+        .iter()
+        .any(|letter| absent_letters[*letter])
+    {
+        return Some(
+            "It reused a gray letter without duplicate-letter evidence to justify it.".to_string(),
+        );
+    }
+    if hard_mode {
+        Some("It would not be playable under the known hard-mode constraints.".to_string())
+    } else {
+        Some("It did not line up with all of the information already on the board.".to_string())
+    }
+}
+
+fn turn_label(turn: &TurnAnalysis) -> &'static str {
+    if turn.constraint_discipline == ConstraintDiscipline::Miss {
+        return "Constraint Miss";
+    }
+    if turn.stage == Stage::Opener {
+        return if opener_is_vowel_heavy(turn) {
+            "Vowel-Heavy Opener"
+        } else {
+            "Balanced Opener"
+        };
+    }
+    if turn.move_type == MoveType::ForcedSolve || turn.move_type == MoveType::SolveAttempt {
+        if turn.candidates_before > 8 && turn.information_bucket <= InformationBucket::Modest {
+            return "Risky Direct Solve";
+        }
+        return "Candidate Solve";
+    }
+    if turn.trap_risk != TrapRisk::Low && turn.information_bucket >= InformationBucket::Solid {
+        return "Trap Breaker";
+    }
+    if turn.duplicate_letter_note == DuplicateLetterNote::Useful {
+        return "Duplicate-Letter Test";
+    }
+    if turn.information_bucket == InformationBucket::Low {
+        return "Low-Information Repeat";
+    }
+    if turn.information_bucket >= InformationBucket::Solid {
+        "Pattern Splitter"
+    } else {
+        "Constraint Builder"
+    }
+}
+
+fn opener_is_vowel_heavy(turn: &TurnAnalysis) -> bool {
+    turn.vowel_count >= 3
+}
+
+fn vowel_count(word: crate::word::Word) -> usize {
+    word.0
+        .iter()
+        .filter(|letter| matches!(letter, b'a' | b'e' | b'i' | b'o' | b'u'))
+        .count()
+}
+
+fn turn_score(turn: &TurnAnalysis) -> i32 {
+    let mut score = 78;
+    match turn.constraint_discipline {
+        ConstraintDiscipline::Clean => score += 4,
+        ConstraintDiscipline::Miss => score -= 30,
+    }
+    match turn.information_bucket {
+        InformationBucket::Sharp => score += 14,
+        InformationBucket::Solid => score += 7,
+        InformationBucket::Modest => score -= 4,
+        InformationBucket::Low => score -= 18,
+    }
+    match turn.move_type {
+        MoveType::ForcedSolve => score += 8,
+        MoveType::SolveAttempt => {
+            if turn.candidates_before > 8 && turn.stage != Stage::Endgame {
+                score -= 8;
+            } else {
+                score += 2;
+            }
+        }
+        MoveType::Probe => {
+            if turn.stage == Stage::Endgame || turn.stage == Stage::Final {
+                score -= 5;
+            }
+        }
+        MoveType::ConstraintMiss => score -= 8,
+    }
+    match turn.duplicate_letter_note {
+        DuplicateLetterNote::Useful => score += 3,
+        DuplicateLetterNote::Risky => score -= 5,
+        DuplicateLetterNote::None => {}
+    }
+    if turn.trap_risk != TrapRisk::Low && turn.information_bucket >= InformationBucket::Solid {
+        score += 5;
+    }
+    if turn.solved_on_turn {
+        score += 8;
+    }
+    score.clamp(0, 100)
+}
+
+fn grade(score: i32) -> &'static str {
+    match score {
+        93..=100 => "A",
+        88..=92 => "A-",
+        83..=87 => "B+",
+        78..=82 => "B",
+        73..=77 => "B-",
+        68..=72 => "C+",
+        62..=67 => "C",
+        56..=61 => "C-",
+        48..=55 => "D",
+        _ => "F",
+    }
+}
+
+fn did_well(turn: &TurnAnalysis, label: &str) -> String {
+    if turn.solved_on_turn {
+        return "It finished the puzzle while respecting the board state.".to_string();
+    }
+    match label {
+        "Balanced Opener" => "It started with a broad mix of useful letters.".to_string(),
+        "Vowel-Heavy Opener" => "It quickly checked vowel shape for the puzzle.".to_string(),
+        "Trap Breaker" => {
+            "It attacked a tight word family instead of guessing one option at a time.".to_string()
+        }
+        "Duplicate-Letter Test" => {
+            "It used a repeat to check whether duplicate letters mattered.".to_string()
+        }
+        "Pattern Splitter" => "It separated the remaining pattern sharply.".to_string(),
+        "Constraint Builder" => {
+            "It kept the known clues in play while adding some new information.".to_string()
+        }
+        "Candidate Solve" => "It was a plausible answer-shaped move for the board.".to_string(),
+        "Risky Direct Solve" => "It gave itself a chance to solve immediately.".to_string(),
+        "Low-Information Repeat" => "It still preserved the basic board constraints.".to_string(),
+        "Constraint Miss" => "It may have been intended as a probe.".to_string(),
+        _ => "It made progress on the board.".to_string(),
+    }
+}
+
+fn missed(turn: &TurnAnalysis) -> String {
+    if let Some(note) = &turn.constraint_note {
+        return note.clone();
+    }
+    if turn.information_bucket == InformationBucket::Low {
+        return "It repeated too much known information and left the answer pool broad."
+            .to_string();
+    }
+    if turn.move_type == MoveType::SolveAttempt
+        && turn.candidates_before > 8
+        && turn.information_bucket <= InformationBucket::Modest
+    {
+        return "It guessed into a still-wide pool where a splitter would have taught more."
+            .to_string();
+    }
+    if turn.duplicate_letter_note == DuplicateLetterNote::Risky {
+        return "The duplicate letter did not earn enough new information for that stage."
+            .to_string();
+    }
+    if turn.stage == Stage::Endgame && turn.move_type == MoveType::Probe {
+        return "Late probes are costly unless they split the main remaining pattern.".to_string();
+    }
+    "No major strategic miss on this turn.".to_string()
+}
+
+fn turn_summary(turn: &TurnAnalysis, label: &str) -> String {
+    match turn.information_bucket {
+        InformationBucket::Sharp if turn.constraint_discipline == ConstraintDiscipline::Miss => {
+            format!("{label}: this found information, but by stepping away from known clues.")
+        }
+        InformationBucket::Sharp => format!("{label}: this narrowed the puzzle sharply."),
+        InformationBucket::Solid => format!("{label}: this was a useful narrowing move."),
+        InformationBucket::Modest => {
+            format!("{label}: this helped, but left similar answers alive.")
+        }
+        InformationBucket::Low => format!("{label}: this did not change the board enough."),
+    }
+}
+
+fn board_inconsistent() -> CoachError {
+    CoachError::new(
+        "board_inconsistent",
+        "This board does not match any possible Wordle answer. Check your tile colors and update the board before getting hints or analysis.",
+    )
+}
+
+pub fn coach_response_json(response: &CoachResponse) -> String {
+    let post_game = response
+        .post_game
+        .as_ref()
+        .map(post_game_json)
+        .unwrap_or_else(|| "null".to_string());
+    let share = response
+        .share
+        .as_ref()
+        .map(share_json)
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        "{{\"intent\":\"{}\",\"board\":{},\"post_game\":{},\"share\":{}}}",
+        response.intent.as_str(),
+        board_json(&response.board),
+        post_game,
+        share
+    )
+}
+
+fn board_json(board: &BoardSummary) -> String {
+    let state = match board.state {
+        BoardState::InProgress => "in_progress",
+        BoardState::Solved { .. } => "solved",
+        BoardState::Lost => "lost",
+    };
+    format!(
+        "{{\"state\":\"{}\",\"turns\":{},\"remaining_candidates\":{}}}",
+        state, board.turns, board.remaining_candidates
+    )
+}
+
+fn post_game_json(report: &PostGameReport) -> String {
+    let grades = report
+        .grades
+        .iter()
+        .map(|grade| format!("\"{}\"", escape_json(grade)))
+        .collect::<Vec<_>>()
+        .join(",");
+    let turns = report
+        .turns
+        .iter()
+        .map(turn_review_json)
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"grades\":[{}],\"turns\":[{}],\"summary\":{}}}",
+        grades,
+        turns,
+        game_summary_json(&report.summary)
+    )
+}
+
+fn turn_review_json(turn: &TurnReview) -> String {
+    format!(
+        "{{\"turn\":{},\"label\":\"{}\",\"grade\":\"{}\",\"move_type\":\"{}\",\"information\":\"{}\",\"constraint_discipline\":\"{}\",\"did_well\":\"{}\",\"missed\":\"{}\",\"summary\":\"{}\"}}",
+        turn.turn,
+        escape_json(&turn.label),
+        escape_json(&turn.grade),
+        turn.move_type.as_str(),
+        turn.information.as_str(),
+        turn.constraint_discipline.as_str(),
+        escape_json(&turn.did_well),
+        escape_json(&turn.missed),
+        escape_json(&turn.summary)
+    )
+}
+
+fn game_summary_json(summary: &GameSummary) -> String {
+    let recovery = summary
+        .best_recovery_turn
+        .map(|turn| turn.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let missed = summary
+        .missed_opportunity
+        .as_ref()
+        .map(|value| format!("\"{}\"", escape_json(value)))
+        .unwrap_or_else(|| "null".to_string());
+    format!(
+        "{{\"best_move_turn\":{},\"most_questionable_turn\":{},\"biggest_information_gain_turn\":{},\"best_recovery_turn\":{},\"missed_opportunity\":{},\"lesson\":\"{}\"}}",
+        summary.best_move_turn,
+        summary.most_questionable_turn,
+        summary.biggest_information_gain_turn,
+        recovery,
+        missed,
+        escape_json(&summary.lesson)
+    )
+}
+
+fn share_json(share: &ShareOutput) -> String {
+    format!(
+        "{{\"text\":\"{}\",\"contains_guess_words\":{}}}",
+        escape_json(&share.text),
+        share.contains_guess_words
+    )
+}
+
+fn escape_json(input: &str) -> String {
+    input
+        .replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\n', "\\n")
+}

--- a/wirdle/src/lib.rs
+++ b/wirdle/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod coach;
 pub mod feedback;
 pub mod filter;
 pub mod lexicon;

--- a/wirdle/src/rank.rs
+++ b/wirdle/src/rank.rs
@@ -3,7 +3,7 @@ use crate::lexicon::EditorialOverrides;
 use crate::past_solutions::PastSolutionIndex;
 use crate::solver::PastSolutionPolicy;
 use crate::word::Word;
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 #[derive(Clone, Debug)]
 pub struct LikelyAnswer {
@@ -76,44 +76,11 @@ pub fn rank_information_guesses(
     if candidates.is_empty() {
         return Vec::new();
     }
-    let answer_probability: HashMap<Word, f64> = likely_answers
+    let mut ranked: Vec<InformationGuess> = legal_guesses
         .iter()
-        .map(|answer| (answer.word, answer.probability))
+        .copied()
+        .map(|guess| evaluate_information_guess(guess, candidates, likely_answers, past))
         .collect();
-    let candidate_set: std::collections::HashSet<Word> = candidates.iter().copied().collect();
-    let mut ranked = Vec::with_capacity(legal_guesses.len());
-
-    for guess in legal_guesses {
-        let mut buckets: HashMap<u16, usize> = HashMap::new();
-        for candidate in candidates {
-            *buckets
-                .entry(evaluate_feedback(*guess, *candidate))
-                .or_insert(0) += 1;
-        }
-        let candidate_count = candidates.len() as f64;
-        let mut entropy = 0.0;
-        let mut expected_remaining = 0.0;
-        let mut worst_case_remaining = 0usize;
-        for bucket_size in buckets.values().copied() {
-            let p = bucket_size as f64 / candidate_count;
-            entropy -= p * p.log2();
-            expected_remaining += p * bucket_size as f64;
-            worst_case_remaining = worst_case_remaining.max(bucket_size);
-        }
-        let is_possible_answer = candidate_set.contains(guess);
-        let answer_prob = answer_probability.get(guess).copied().unwrap_or(0.0);
-        let score = entropy + answer_prob + if is_possible_answer { 0.05 } else { 0.0 }
-            - (expected_remaining / candidate_count) * 0.10;
-        ranked.push(InformationGuess {
-            word: *guess,
-            entropy_bits: entropy,
-            expected_remaining,
-            worst_case_remaining,
-            is_possible_answer,
-            used_before: past.was_ever_solution(*guess),
-            score,
-        });
-    }
 
     ranked.sort_by(|a, b| {
         b.score
@@ -123,6 +90,63 @@ pub fn rank_information_guesses(
             .then_with(|| a.word.cmp(&b.word))
     });
     ranked
+}
+
+pub fn evaluate_information_guess(
+    guess: Word,
+    candidates: &[Word],
+    likely_answers: &[LikelyAnswer],
+    past: &PastSolutionIndex,
+) -> InformationGuess {
+    if candidates.is_empty() {
+        return InformationGuess {
+            word: guess,
+            entropy_bits: 0.0,
+            expected_remaining: 0.0,
+            worst_case_remaining: 0,
+            is_possible_answer: false,
+            used_before: past.was_ever_solution(guess),
+            score: 0.0,
+        };
+    }
+
+    let answer_probability: HashMap<Word, f64> = likely_answers
+        .iter()
+        .map(|answer| (answer.word, answer.probability))
+        .collect();
+    let candidate_set: HashSet<Word> = candidates.iter().copied().collect();
+    let mut buckets: HashMap<u16, usize> = HashMap::new();
+    for candidate in candidates {
+        *buckets
+            .entry(evaluate_feedback(guess, *candidate))
+            .or_insert(0) += 1;
+    }
+
+    let candidate_count = candidates.len() as f64;
+    let mut entropy = 0.0;
+    let mut expected_remaining = 0.0;
+    let mut worst_case_remaining = 0usize;
+    for bucket_size in buckets.values().copied() {
+        let p = bucket_size as f64 / candidate_count;
+        entropy -= p * p.log2();
+        expected_remaining += p * bucket_size as f64;
+        worst_case_remaining = worst_case_remaining.max(bucket_size);
+    }
+
+    let is_possible_answer = candidate_set.contains(&guess);
+    let answer_prob = answer_probability.get(&guess).copied().unwrap_or(0.0);
+    let score = entropy + answer_prob + if is_possible_answer { 0.05 } else { 0.0 }
+        - (expected_remaining / candidate_count) * 0.10;
+
+    InformationGuess {
+        word: guess,
+        entropy_bits: entropy,
+        expected_remaining,
+        worst_case_remaining,
+        is_possible_answer,
+        used_before: past.was_ever_solution(guess),
+        score,
+    }
 }
 
 fn positional_letter_priors(candidates: &[Word]) -> [[f64; 26]; 5] {

--- a/wirdle/src/server.rs
+++ b/wirdle/src/server.rs
@@ -1,3 +1,4 @@
+use crate::coach::{CoachIntent, CoachRequest, coach, coach_response_json};
 use crate::feedback::LetterStatus;
 use crate::filter::GuessInput;
 use crate::solver::{PastSolutionPolicy, SolveMode, SolveRequest, SolveResponse, Solver};
@@ -116,11 +117,53 @@ pub fn handle_http_request(raw: &str, solver: &Solver) -> (&'static str, &'stati
             ),
         };
     }
+    if first.starts_with("POST /v1/coach ") {
+        let body = raw.split("\r\n\r\n").nth(1).unwrap_or_default();
+        return match parse_coach_request(body) {
+            Ok(request) => match coach(solver, &request) {
+                Ok(response) => ("200 OK", "application/json", coach_response_json(&response)),
+                Err(err) => (
+                    if err.code == "invalid_request" {
+                        "400 Bad Request"
+                    } else {
+                        "422 Unprocessable Entity"
+                    },
+                    "application/json",
+                    format!(
+                        "{{\"error\":\"{}\",\"message\":\"{}\"}}",
+                        err.code,
+                        escape_json(&err.message)
+                    ),
+                ),
+            },
+            Err(message) => (
+                "400 Bad Request",
+                "application/json",
+                format!(
+                    "{{\"error\":\"invalid_request\",\"message\":\"{}\"}}",
+                    escape_json(&message)
+                ),
+            ),
+        };
+    }
     (
         "404 Not Found",
         "application/json",
         "{\"error\":\"not_found\",\"message\":\"Unknown route\"}".to_string(),
     )
+}
+
+pub fn parse_coach_request(json: &str) -> Result<CoachRequest, String> {
+    let intent_value = json_string(json, "intent").ok_or("coach request is missing intent")?;
+    let intent = CoachIntent::parse(&intent_value)
+        .ok_or_else(|| format!("unsupported coach intent '{intent_value}'"))?;
+    let solve_request = parse_solve_request(json)?;
+
+    Ok(CoachRequest {
+        intent,
+        guesses: solve_request.guesses,
+        hard_mode: json_bool(json, "hard_mode").unwrap_or(false),
+    })
 }
 
 pub fn parse_solve_request(json: &str) -> Result<SolveRequest, String> {

--- a/wirdle/static/index.html
+++ b/wirdle/static/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <title>Wirdle - Wordle Solver</title>
+    <title>Wirdle - Wordle Coach</title>
     <style>
       :root {
         --bg: #f7f7f3;
@@ -312,6 +312,99 @@
         gap: 10px;
       }
 
+      .mode-stack {
+        display: grid;
+        gap: 14px;
+      }
+
+      .mode-panel {
+        display: grid;
+        gap: 12px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 14px;
+      }
+
+      .mode-panel.primary-panel {
+        border-color: color-mix(in srgb, var(--accent) 38%, var(--line));
+      }
+
+      .panel-copy {
+        margin: 0;
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 1.4;
+      }
+
+      .coach-report {
+        display: grid;
+        gap: 12px;
+      }
+
+      .summary-band {
+        display: grid;
+        gap: 6px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #fbfaf7;
+        padding: 12px;
+      }
+
+      .summary-line {
+        margin: 0;
+        color: var(--muted);
+        font-size: 14px;
+        line-height: 1.4;
+      }
+
+      .turn-timeline {
+        display: grid;
+        gap: 8px;
+      }
+
+      .turn-review {
+        display: grid;
+        gap: 7px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: var(--panel);
+        padding: 12px;
+      }
+
+      .turn-review-header {
+        display: flex;
+        align-items: baseline;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .turn-title {
+        font-size: 15px;
+        font-weight: 800;
+      }
+
+      .turn-grade {
+        border-radius: 999px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        padding: 3px 8px;
+        font-size: 13px;
+        font-weight: 800;
+      }
+
+      .turn-copy {
+        margin: 0;
+        color: var(--muted);
+        font-size: 13px;
+        line-height: 1.4;
+      }
+
+      .advanced-shell[hidden],
+      .coach-report[hidden] {
+        display: none;
+      }
+
       .section-heading {
         display: flex;
         align-items: baseline;
@@ -576,7 +669,7 @@
           font-size: 48px;
         }
 
-        .recommendations {
+        .mode-stack {
           padding-top: 4px;
         }
       }
@@ -673,56 +766,77 @@
           <div class="message" id="message" aria-live="polite"></div>
         </section>
 
-        <section class="recommendations" aria-label="Recommendations">
-          <div class="section-heading">
-            <h2>Suggestions</h2>
-            <div class="ranking-note" id="rankingNote">Best move</div>
-          </div>
-          <div class="tabs" role="tablist" aria-label="Suggestion type">
-            <div class="tab-option">
-              <button
-                class="tab-button"
-                id="tab-power"
-                type="button"
-                role="tab"
-                aria-selected="true"
-                aria-controls="recommendations"
-                data-tab="power"
-              >
-                Power Words
-              </button>
-              <button
-                class="info-button tab-info-button"
-                type="button"
-                data-info-action="power-tab"
-                aria-label="About Power Words"
-              >
-                ?
-              </button>
+        <section class="mode-stack" aria-label="Wirdle modes">
+          <section class="mode-panel primary-panel" aria-label="Post Game">
+            <div class="section-heading">
+              <h2>Post Game</h2>
+              <div class="ranking-note" id="postGameState">Finish board</div>
             </div>
-            <div class="tab-option">
-              <button
-                class="tab-button"
-                id="tab-answers"
-                type="button"
-                role="tab"
-                aria-selected="false"
-                aria-controls="recommendations"
-                data-tab="answers"
-              >
-                Answers
-              </button>
-              <button
-                class="info-button tab-info-button"
-                type="button"
-                data-info-action="answers-tab"
-                aria-label="About Answers"
-              >
-                ?
-              </button>
+            <button class="action-button primary" id="reviewGame" type="button" disabled>
+              Review my game
+            </button>
+            <div class="coach-report" id="coachReport" hidden></div>
+          </section>
+
+          <section class="mode-panel" aria-label="Advanced Analyses">
+            <div class="section-heading">
+              <h2>Advanced Analyses</h2>
+              <div class="ranking-note" id="rankingNote">Spoiler gated</div>
             </div>
-          </div>
-          <div class="recommendation-list" id="recommendations"></div>
+            <p class="panel-copy">
+              Solver-style rankings can reveal likely answers and reduce the challenge.
+            </p>
+            <button class="action-button" id="showAdvanced" type="button">
+              Show Advanced Analyses
+            </button>
+            <div class="advanced-shell" id="advancedShell" hidden>
+              <div class="tabs" role="tablist" aria-label="Suggestion type">
+                <div class="tab-option">
+                  <button
+                    class="tab-button"
+                    id="tab-power"
+                    type="button"
+                    role="tab"
+                    aria-selected="true"
+                    aria-controls="recommendations"
+                    data-tab="power"
+                  >
+                    Power Words
+                  </button>
+                  <button
+                    class="info-button tab-info-button"
+                    type="button"
+                    data-info-action="power-tab"
+                    aria-label="About Power Words"
+                  >
+                    ?
+                  </button>
+                </div>
+                <div class="tab-option">
+                  <button
+                    class="tab-button"
+                    id="tab-answers"
+                    type="button"
+                    role="tab"
+                    aria-selected="false"
+                    aria-controls="recommendations"
+                    data-tab="answers"
+                  >
+                    Answers
+                  </button>
+                  <button
+                    class="info-button tab-info-button"
+                    type="button"
+                    data-info-action="answers-tab"
+                    aria-label="About Answers"
+                  >
+                    ?
+                  </button>
+                </div>
+              </div>
+              <div class="recommendation-list" id="recommendations"></div>
+            </div>
+          </section>
         </section>
       </div>
     </main>
@@ -746,6 +860,11 @@
       const message = document.querySelector("#message");
       const recommendations = document.querySelector("#recommendations");
       const rankingNote = document.querySelector("#rankingNote");
+      const postGameState = document.querySelector("#postGameState");
+      const reviewGameButton = document.querySelector("#reviewGame");
+      const coachReport = document.querySelector("#coachReport");
+      const showAdvancedButton = document.querySelector("#showAdvanced");
+      const advancedShell = document.querySelector("#advancedShell");
       const dataInfo = document.querySelector("#dataInfo");
       const addGuessButton = document.querySelector("#addGuess");
       const undoButton = document.querySelector("#undo");
@@ -767,6 +886,10 @@
       let answersExpanded = false;
       let wordListInfo = null;
       let activeOverlayKind = null;
+      let activeOverlayAction = null;
+      let advancedConfirmed = false;
+      let latestCoachId = 0;
+      let latestShareText = "";
 
       function setMessage(text, isError = false) {
         message.textContent = text;
@@ -789,6 +912,40 @@
         return new Intl.NumberFormat().format(value);
       }
 
+      function solvedTurn() {
+        const index = submittedGuesses.findIndex((guess) =>
+          guess.statuses.every((status) => status === "correct"),
+        );
+        return index === -1 ? null : index + 1;
+      }
+
+      function isBoardComplete() {
+        return solvedTurn() !== null || submittedGuesses.length === ROW_COUNT;
+      }
+
+      function canEditActiveRow() {
+        return submittedGuesses.length < ROW_COUNT && solvedTurn() === null;
+      }
+
+      function clearCoachReport() {
+        latestCoachId += 1;
+        latestShareText = "";
+        coachReport.hidden = true;
+        coachReport.innerHTML = "";
+      }
+
+      function syncPostGameState() {
+        const turn = solvedTurn();
+        if (turn !== null) {
+          postGameState.textContent = `Solved in ${turn}`;
+        } else if (submittedGuesses.length === ROW_COUNT) {
+          postGameState.textContent = "Six rows";
+        } else {
+          postGameState.textContent = "Finish board";
+        }
+        reviewGameButton.disabled = !isBoardComplete();
+      }
+
       function isCoachDismissed() {
         try {
           return localStorage.getItem(COACH_STORAGE_KEY) === "true";
@@ -803,10 +960,18 @@
         } catch (_err) {}
       }
 
-      function openOverlay(title, body, kind = "info") {
+      function openOverlay(
+        title,
+        body,
+        kind = "info",
+        actionLabel = "Got it",
+        onAction = null,
+      ) {
         activeOverlayKind = kind;
+        activeOverlayAction = onAction;
         overlayTitle.textContent = title;
         overlayBody.innerHTML = body;
+        overlayAction.textContent = actionLabel;
         infoOverlay.hidden = false;
         overlayClose.focus({ preventScroll: true });
       }
@@ -816,6 +981,8 @@
           markCoachDismissed();
         }
         activeOverlayKind = null;
+        activeOverlayAction = null;
+        overlayAction.textContent = "Got it";
         infoOverlay.hidden = true;
       }
 
@@ -824,9 +991,8 @@
           "How Wirdle Helps",
           `
             <p>Wirdle does not know today&apos;s answer. Play a guess in Wordle, add that same word here, then tap the tiles to match Wordle&apos;s colors.</p>
-            <p><strong>Power Words</strong> are optional boosts. They are not answers, but they can reveal more information when you want superhero help.</p>
-            <p><strong>Answers</strong> is the peek tab. Use it when you want to compare possible solutions or when you are ready for a stronger nudge.</p>
-            <p>Tapping any suggestion only fills the next row. It does not submit the guess or set any colors.</p>
+            <p><strong>Post Game</strong> reviews a finished board with grades, turn notes, and share text.</p>
+            <p><strong>Advanced Analyses</strong> keeps the old solver-style rankings behind a spoiler warning.</p>
           `,
           "coach",
         );
@@ -881,6 +1047,7 @@
           const current = statuses.indexOf(status);
           submitted.statuses[tileIndex] =
             statuses[(current + 1) % statuses.length];
+          clearCoachReport();
           renderBoard();
           refreshRecommendations();
           focusKeyboard();
@@ -904,14 +1071,15 @@
         resetButton.disabled =
           submittedGuesses.length === 0 && activeLetters.length === 0;
         addGuessButton.disabled =
-          submittedGuesses.length >= ROW_COUNT ||
+          !canEditActiveRow() ||
           activeLetters.length !== WORD_LENGTH;
         syncKeyboardCapture();
+        syncPostGameState();
       }
 
       function addLetter(letter) {
         if (
-          submittedGuesses.length >= ROW_COUNT ||
+          !canEditActiveRow() ||
           activeLetters.length >= WORD_LENGTH
         ) {
           return;
@@ -934,6 +1102,10 @@
         if (submittedGuesses.length >= ROW_COUNT) {
           return;
         }
+        if (solvedTurn() !== null) {
+          setMessage("The board is already solved.", true);
+          return;
+        }
         if (activeLetters.length !== WORD_LENGTH) {
           setMessage("Five letters needed.", true);
           return;
@@ -943,17 +1115,19 @@
           statuses: ["absent", "absent", "absent", "absent", "absent"],
         });
         activeLetters = [];
+        clearCoachReport();
         renderBoard();
         refreshRecommendations();
         setMessage("");
       }
 
       function fillActiveRow(word) {
-        if (submittedGuesses.length >= ROW_COUNT) {
+        if (!canEditActiveRow()) {
           setMessage("All rows are filled.", true);
           return;
         }
         activeLetters = word.toLowerCase().slice(0, WORD_LENGTH).split("");
+        clearCoachReport();
         renderBoard();
         focusKeyboard();
         setMessage("");
@@ -1039,6 +1213,24 @@
             <p>Chance is Wirdle&apos;s rough ranking for which remaining word looks most plausible. It is not secret knowledge from Wordle.</p>
             <p>Never used before means the word is not in Wirdle&apos;s loaded historical answer data. Used before means it is in that data, but Wordle repeats are still possible.</p>
           `,
+        );
+      }
+
+      function openAdvancedWarning() {
+        openOverlay(
+          "Advanced Analyses",
+          `
+            <p>Advanced Analyses can reveal likely answers and reduce the challenge of today&apos;s Wordle.</p>
+            <p>Continue only if you want solver-style rankings for the board you entered.</p>
+          `,
+          "advanced",
+          "Show analyses",
+          () => {
+            advancedConfirmed = true;
+            advancedShell.hidden = false;
+            showAdvancedButton.hidden = true;
+            refreshRecommendations();
+          },
         );
       }
 
@@ -1159,7 +1351,109 @@
         renderPowerWords(data);
       }
 
+      function escapeHtml(value) {
+        return String(value)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;");
+      }
+
+      function renderCoachReport(data) {
+        const report = data.post_game;
+        const summary = report.summary;
+        const missed = summary.missed_opportunity
+          ? `<p class="summary-line">${escapeHtml(summary.missed_opportunity)}</p>`
+          : "";
+        const recovery =
+          summary.best_recovery_turn === null
+            ? ""
+            : `<p class="summary-line">Best recovery: turn ${summary.best_recovery_turn}.</p>`;
+        const turns = report.turns
+          .map(
+            (turn) => `
+              <article class="turn-review">
+                <div class="turn-review-header">
+                  <div class="turn-title">Turn ${turn.turn}: ${escapeHtml(turn.label)}</div>
+                  <div class="turn-grade">${escapeHtml(turn.grade)}</div>
+                </div>
+                <p class="turn-copy">${escapeHtml(turn.summary)}</p>
+                <p class="turn-copy">${escapeHtml(turn.did_well)}</p>
+                <p class="turn-copy">${escapeHtml(turn.missed)}</p>
+              </article>
+            `,
+          )
+          .join("");
+
+        latestShareText = data.share?.text || "";
+        coachReport.innerHTML = `
+          <div class="summary-band">
+            <p class="summary-line">Best move: turn ${summary.best_move_turn}. Biggest information gain: turn ${summary.biggest_information_gain_turn}.</p>
+            <p class="summary-line">Most questionable move: turn ${summary.most_questionable_turn}.</p>
+            ${recovery}
+            ${missed}
+            <p class="summary-line">${escapeHtml(summary.lesson)}</p>
+          </div>
+          <button class="action-button" id="copyShare" type="button">Copy share text</button>
+          <div class="turn-timeline">${turns}</div>
+        `;
+        coachReport.hidden = false;
+      }
+
+      async function reviewGame() {
+        if (!isBoardComplete()) {
+          setMessage("Finish the Wordle board before reviewing your game.", true);
+          return;
+        }
+        const coachId = latestCoachId + 1;
+        latestCoachId = coachId;
+        reviewGameButton.disabled = true;
+        reviewGameButton.textContent = "Reviewing...";
+        setMessage("");
+
+        try {
+          const response = await fetch("/v1/coach", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              intent: "post_game_review",
+              guesses: submittedGuesses,
+              hard_mode: false,
+            }),
+          });
+          const data = await response.json();
+          if (coachId !== latestCoachId) {
+            return;
+          }
+          if (!response.ok) {
+            latestShareText = "";
+            coachReport.hidden = true;
+            coachReport.innerHTML = "";
+            setMessage(data.message || "Board could not be reviewed.", true);
+            return;
+          }
+          renderCoachReport(data);
+          setMessage("");
+        } catch (_err) {
+          if (coachId === latestCoachId) {
+            latestShareText = "";
+            coachReport.hidden = true;
+            coachReport.innerHTML = "";
+            setMessage("Post-game review unavailable.", true);
+          }
+        } finally {
+          if (coachId === latestCoachId) {
+            reviewGameButton.textContent = "Review my game";
+            syncPostGameState();
+          }
+        }
+      }
+
       async function refreshRecommendations() {
+        if (!advancedConfirmed) {
+          latestRecommendationData = null;
+          return;
+        }
         const solveId = latestSolveId + 1;
         latestSolveId = solveId;
         rankingNote.textContent =
@@ -1262,6 +1556,7 @@
           .replace(/[^a-z]/g, "")
           .slice(0, WORD_LENGTH);
         activeLetters = letters.split("");
+        clearCoachReport();
         renderBoard();
       });
 
@@ -1275,6 +1570,7 @@
 
       undoButton.addEventListener("click", () => {
         submittedGuesses.pop();
+        clearCoachReport();
         renderBoard();
         refreshRecommendations();
         focusKeyboard();
@@ -1283,17 +1579,26 @@
       resetButton.addEventListener("click", () => {
         submittedGuesses.length = 0;
         activeLetters = [];
+        clearCoachReport();
         renderBoard();
         refreshRecommendations();
         focusKeyboard();
       });
 
       dataInfo.addEventListener("click", openDataInfo);
+      reviewGameButton.addEventListener("click", reviewGame);
+      showAdvancedButton.addEventListener("click", openAdvancedWarning);
       coachHelp.addEventListener("click", () => {
         openCoach();
       });
       overlayClose.addEventListener("click", closeOverlay);
-      overlayAction.addEventListener("click", closeOverlay);
+      overlayAction.addEventListener("click", () => {
+        const action = activeOverlayAction;
+        closeOverlay();
+        if (action) {
+          action();
+        }
+      });
       infoOverlay.addEventListener("click", (event) => {
         if (event.target.closest("[data-close-overlay]")) {
           closeOverlay();
@@ -1323,6 +1628,22 @@
         }
         if (action === "answers-tab") {
           openAnswersInfo();
+        }
+      });
+
+      coachReport.addEventListener("click", async (event) => {
+        if (!event.target.closest("#copyShare")) {
+          return;
+        }
+        if (!latestShareText) {
+          setMessage("Share text unavailable.", true);
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(latestShareText);
+          setMessage("Share text copied.");
+        } catch (_err) {
+          setMessage("Share text could not be copied.", true);
         }
       });
 

--- a/wirdle/tests/core.rs
+++ b/wirdle/tests/core.rs
@@ -1,6 +1,8 @@
-use wordle_api::feedback::{LetterStatus::*, pattern_from_statuses};
+use wordle_api::coach::{CoachIntent, CoachRequest, coach, status_grid_row};
+use wordle_api::feedback::{LetterStatus::*, pattern_from_statuses, statuses_from_pattern};
 use wordle_api::filter::GuessInput;
-use wordle_api::server::{handle_http_request, parse_solve_request};
+use wordle_api::rank::{evaluate_information_guess, rank_information_guesses, rank_likely_answers};
+use wordle_api::server::{handle_http_request, parse_coach_request, parse_solve_request};
 use wordle_api::solver::{PastSolutionPolicy, SolveMode, SolveRequest, entry};
 use wordle_api::{
     EditorialOverrides, Lexicon, PastSolutionIndex, Solver, Word, evaluate_feedback,
@@ -13,6 +15,20 @@ fn word(input: &str) -> Word {
 
 fn fixture_solver() -> Solver {
     Solver::load("wordle-data").unwrap()
+}
+
+fn played_game(answer: &str, guesses: &[&str]) -> Vec<GuessInput> {
+    let answer = word(answer);
+    guesses
+        .iter()
+        .map(|guess| {
+            let guess = word(guess);
+            GuessInput::new(
+                guess,
+                statuses_from_pattern(evaluate_feedback(guess, answer)),
+            )
+        })
+        .collect()
 }
 
 #[test]
@@ -170,6 +186,137 @@ fn hard_mode_limits_information_guesses_to_consistent_words() {
 }
 
 #[test]
+fn evaluate_information_guess_matches_ranked_information_values() {
+    let solver = fixture_solver();
+    let candidates = vec![word("couch"), word("clang"), word("divot")];
+    let policy = PastSolutionPolicy {
+        enabled: false,
+        ..PastSolutionPolicy::default()
+    };
+    let likely = rank_likely_answers(
+        &candidates,
+        solver.past(),
+        &policy,
+        &solver.lexicon().overrides,
+    );
+    let ranked = rank_information_guesses(&[word("slate")], &candidates, &likely, solver.past());
+    let evaluated = evaluate_information_guess(word("slate"), &candidates, &likely, solver.past());
+
+    assert_eq!(ranked.len(), 1);
+    assert_eq!(ranked[0].word, evaluated.word);
+    assert_eq!(
+        ranked[0].worst_case_remaining,
+        evaluated.worst_case_remaining
+    );
+    assert_eq!(ranked[0].is_possible_answer, evaluated.is_possible_answer);
+    assert!((ranked[0].entropy_bits - evaluated.entropy_bits).abs() < f64::EPSILON);
+    assert!((ranked[0].expected_remaining - evaluated.expected_remaining).abs() < f64::EPSILON);
+    assert!((ranked[0].score - evaluated.score).abs() < f64::EPSILON);
+}
+
+#[test]
+fn post_game_coach_accepts_solved_board_and_omits_guess_words_from_share() {
+    let solver = fixture_solver();
+    let guesses = played_game("visit", &["slate", "crown", "visit"]);
+    let response = coach(
+        &solver,
+        &CoachRequest {
+            intent: CoachIntent::PostGameReview,
+            guesses: guesses.clone(),
+            hard_mode: false,
+        },
+    )
+    .unwrap();
+    let report = response.post_game.as_ref().unwrap();
+    let share = response.share.as_ref().unwrap();
+
+    assert_eq!(response.board.turns, 3);
+    assert_eq!(report.turns.len(), 3);
+    assert_eq!(report.grades.len(), 3);
+    assert!(share.text.contains("Wirdle: Post Game Mode"));
+    assert!(share.text.contains("wirdle.onrender.com"));
+    assert!(!share.contains_guess_words);
+    for guess in guesses {
+        assert!(!share.text.to_lowercase().contains(guess.word.as_str()));
+    }
+}
+
+#[test]
+fn post_game_coach_accepts_six_row_loss() {
+    let solver = fixture_solver();
+    let guesses = played_game(
+        "couch",
+        &["slate", "pride", "brink", "flame", "gypsy", "zonal"],
+    );
+    let response = coach(
+        &solver,
+        &CoachRequest {
+            intent: CoachIntent::PostGameReview,
+            guesses,
+            hard_mode: false,
+        },
+    )
+    .unwrap();
+
+    assert_eq!(response.board.turns, 6);
+    assert!(response.share.unwrap().text.starts_with("Wordle X/6"));
+}
+
+#[test]
+fn post_game_coach_rejects_incomplete_and_inconsistent_boards() {
+    let solver = fixture_solver();
+    let incomplete = coach(
+        &solver,
+        &CoachRequest {
+            intent: CoachIntent::PostGameReview,
+            guesses: played_game("visit", &["slate"]),
+            hard_mode: false,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(incomplete.code, "board_incomplete");
+
+    let inconsistent = coach(
+        &solver,
+        &CoachRequest {
+            intent: CoachIntent::PostGameReview,
+            guesses: vec![GuessInput::new(
+                word("slate"),
+                [Present, Present, Present, Present, Present],
+            )],
+            hard_mode: false,
+        },
+    )
+    .unwrap_err();
+    assert_eq!(inconsistent.code, "board_inconsistent");
+}
+
+#[test]
+fn post_game_coach_rejects_rows_after_solve() {
+    let solver = fixture_solver();
+    let guesses = played_game("visit", &["visit", "couch"]);
+    let err = coach(
+        &solver,
+        &CoachRequest {
+            intent: CoachIntent::PostGameReview,
+            guesses,
+            hard_mode: false,
+        },
+    )
+    .unwrap_err();
+
+    assert_eq!(err.code, "invalid_request");
+}
+
+#[test]
+fn share_grid_renders_wordle_squares() {
+    assert_eq!(
+        status_grid_row(&[Absent, Present, Correct, Absent, Correct]),
+        "⬛🟨🟩⬛🟩"
+    );
+}
+
+#[test]
 fn parses_and_handles_solve_http_request() {
     let body = r#"{
       "guesses": [{"word": "slate", "statuses": ["absent", "absent", "absent", "absent", "absent"]}],
@@ -193,13 +340,82 @@ fn parses_and_handles_solve_http_request() {
 }
 
 #[test]
+fn parses_and_handles_coach_http_request() {
+    let guesses = played_game("visit", &["slate", "crown", "visit"]);
+    let guesses_json = guesses
+        .iter()
+        .map(|guess| {
+            format!(
+                "{{\"word\":\"{}\",\"statuses\":{}}}",
+                guess.word,
+                wordle_api::solver::statuses_json(&guess.statuses)
+            )
+        })
+        .collect::<Vec<_>>()
+        .join(",");
+    let body = format!(
+        "{{\"intent\":\"post_game_review\",\"guesses\":[{}],\"hard_mode\":false}}",
+        guesses_json
+    );
+    let parsed = parse_coach_request(&body).unwrap();
+    assert_eq!(parsed.intent, CoachIntent::PostGameReview);
+    assert_eq!(parsed.guesses.len(), 3);
+
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let (status, content_type, response) = handle_http_request(&request, &fixture_solver());
+    assert_eq!(status, "200 OK");
+    assert_eq!(content_type, "application/json");
+    assert!(response.contains("\"post_game\""));
+    assert!(response.contains("wirdle.onrender.com"));
+}
+
+#[test]
+fn coach_http_rejects_malformed_incomplete_and_inconsistent_boards() {
+    let solver = fixture_solver();
+    let malformed =
+        r#"{"intent":"post_game_review","guesses":[{"word":"slate","statuses":["absent"]}]}"#;
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        malformed.len(),
+        malformed
+    );
+    let (status, _, response) = handle_http_request(&request, &solver);
+    assert_eq!(status, "400 Bad Request");
+    assert!(response.contains("guess statuses must contain five values"));
+
+    let incomplete = r#"{"intent":"post_game_review","guesses":[{"word":"slate","statuses":["absent","absent","absent","absent","absent"]}]}"#;
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        incomplete.len(),
+        incomplete
+    );
+    let (status, _, response) = handle_http_request(&request, &solver);
+    assert_eq!(status, "422 Unprocessable Entity");
+    assert!(response.contains("board_incomplete"));
+
+    let inconsistent = r#"{"intent":"post_game_review","guesses":[{"word":"slate","statuses":["present","present","present","present","present"]}]}"#;
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        inconsistent.len(),
+        inconsistent
+    );
+    let (status, _, response) = handle_http_request(&request, &solver);
+    assert_eq!(status, "422 Unprocessable Entity");
+    assert!(response.contains("board_inconsistent"));
+}
+
+#[test]
 fn serves_static_ui_as_html() {
     let (status, content_type, response) =
         handle_http_request("GET / HTTP/1.1\r\n\r\n", &fixture_solver());
 
     assert_eq!(status, "200 OK");
     assert_eq!(content_type, "text/html; charset=utf-8");
-    assert!(response.contains("Wordle Solver"));
+    assert!(response.contains("Wordle Coach"));
 }
 
 #[test]

--- a/wirdle/wirdle-v2-m1-design.md
+++ b/wirdle/wirdle-v2-m1-design.md
@@ -1,0 +1,596 @@
+# Wirdle v2 Milestone 1 Engineering Design
+
+## Summary
+
+Milestone 1 turns Wirdle from a default solver UI into a post-game coach while preserving the existing board recreation workflow and solver engine.
+
+The implementation adds a shared coach analysis layer and one new HTTP endpoint, `POST /v1/coach`, for user-facing coaching output. In M1 the endpoint supports only post-game review. In M2 the same endpoint can support Easy Mode hints by adding a new request intent and hint-specific response field. The existing `POST /v1/solve` endpoint remains available for Advanced Analyses after an explicit spoiler warning.
+
+This keeps the public API small:
+
+- Keep `/v1/solve` for solver-grade Advanced Analyses.
+- Add `/v1/coach` for all human-facing coaching modes.
+- Do not add separate `/v1/review`, `/v1/hint`, or `/v1/share` endpoints.
+
+## Goals
+
+- Generate a deterministic post-game report for a completed board.
+- Produce turn-by-turn labels, letter grades, strengths, misses, and coaching notes.
+- Generate a concise game summary and share text with no guess words.
+- Reject inconsistent boards with a repair-focused error before producing grades, hints, or share text.
+- Move existing solver recommendations behind an Advanced Analyses warning.
+- Structure the coach layer so M2 Easy Mode hints reuse the same board analysis and API envelope.
+
+## Non-Goals
+
+- No live hint ladder in M1.
+- No considered guesses in M1.
+- No account-backed history or learning over time.
+- No automatic NYT import.
+- No new solver-ranking endpoint beyond the existing `/v1/solve`.
+- No exact candidate lists or entropy-style math in the default post-game report.
+- No M1 UI controls for puzzle number, puzzle date, or Hard Mode.
+
+## Resolved Product Decisions
+
+- M1 does not ask for puzzle number or date. Share text uses the entered board result and grid without puzzle metadata.
+- M1 report copy refers to turn numbers and strategy labels, not guess words. This avoids ambiguity because Wordle allows repeated guesses.
+- M1 keeps `hard_mode` as an API field with a default of `false`, but does not expose a Hard Mode control in the UI. Easy Mode can introduce that control later when live hints or concrete guess help need to avoid unplayable Hard Mode suggestions.
+
+## Current System
+
+The repo currently has:
+
+- Manual board input in `static/index.html`.
+- A dependency-free Rust server in `src/server.rs`.
+- Core Wordle primitives:
+  - `Word` parsing and validation.
+  - `LetterStatus` feedback.
+  - `GuessInput`.
+  - `filter_candidates` and `is_candidate_consistent`.
+  - likely-answer ranking.
+  - information-gain ranking.
+  - past-solution weighting.
+- HTTP routes:
+  - `GET /`
+  - `GET /v1/health`
+  - `GET /v1/metadata`
+  - `POST /v1/solve`
+
+M1 should reuse those primitives instead of adding a separate coaching model.
+
+## Architecture
+
+```text
+Browser board state
+        |
+        | POST /v1/coach { intent: "post_game_review", guesses, ... }
+        v
+HTTP parser in src/server.rs
+        |
+        v
+Coach layer in src/coach.rs
+        |
+        +--> BoardAnalysis
+        |       - completion state
+        |       - consistency state
+        |       - per-turn candidate counts
+        |       - per-turn information value
+        |       - constraint discipline
+        |       - solve/probe classification
+        |       - trap and duplicate-letter notes
+        |
+        +--> PostGameReport
+        |       - turn reviews
+        |       - summary
+        |       - share text
+        |
+        v
+JSON response for UI rendering
+```
+
+`BoardAnalysis` is the shared internal contract. Post Game uses it in M1. Easy Mode uses it in M2 to choose the next hint level without duplicating board validation, candidate filtering, constraint notes, or stage detection.
+
+## API Surface
+
+### Endpoint Decision
+
+Add:
+
+```text
+POST /v1/coach
+```
+
+Do not add separate endpoints for report generation, hint generation, and share text. The endpoint is stateless and derives output from the submitted board plus optional UI/session context.
+
+`POST /v1/solve` stays as the Advanced Analyses endpoint. The UI should call it only after the user confirms the spoiler warning.
+
+### M1 Request
+
+```json
+{
+  "intent": "post_game_review",
+  "guesses": [
+    {
+      "word": "slate",
+      "statuses": ["absent", "present", "absent", "correct", "absent"]
+    }
+  ]
+}
+```
+
+Fields:
+
+- `intent`: required. M1 accepts only `post_game_review`.
+- `guesses`: required. Same shape as `/v1/solve`.
+- `hard_mode`: optional, default `false`. Kept for API compatibility, but the M1 UI does not expose it.
+- `share_context`: optional and reserved for later. The M1 UI does not send puzzle number or date.
+
+### M2-Compatible Request Extension
+
+M2 can extend the same endpoint:
+
+```json
+{
+  "intent": "easy_hint",
+  "guesses": [
+    {
+      "word": "slate",
+      "statuses": ["absent", "present", "absent", "correct", "absent"]
+    }
+  ],
+  "hard_mode": false,
+  "hint_request": {
+    "requested_level": 2,
+    "explain_current": false,
+    "confirmed_spoiler": false
+  },
+  "session_context": {
+    "highest_hint_level_used": 1
+  }
+}
+```
+
+M1 does not implement `easy_hint`, but the envelope reserves obvious slots for it. This avoids adding a future `/v1/hint` endpoint and makes share generation consume the same session context later.
+
+### M1 Success Response
+
+```json
+{
+  "intent": "post_game_review",
+  "board": {
+    "state": "solved",
+    "turns": 4,
+    "remaining_candidates": 1
+  },
+  "post_game": {
+    "grades": ["B+", "B", "A-", "A"],
+    "turns": [
+      {
+        "turn": 1,
+        "label": "Balanced Opener",
+        "grade": "B+",
+        "move_type": "probe",
+        "information": "solid",
+        "constraint_discipline": "clean",
+        "did_well": "It tested a balanced mix of useful letters.",
+        "missed": "It did not narrow the ending much.",
+        "summary": "A sound opening probe."
+      }
+    ],
+    "summary": {
+      "best_move_turn": 4,
+      "most_questionable_turn": 2,
+      "biggest_information_gain_turn": 3,
+      "best_recovery_turn": null,
+      "missed_opportunity": "Turn 2 could have spent more effort on the main pattern uncertainty.",
+      "lesson": "When a word family is forming, switch from one-by-one guesses to a pattern splitter."
+    }
+  },
+  "share": {
+    "text": "Wordle 4/6\n...\n\nWirdle: Post Game Mode\nGrades: B+ / B / A- / A\nCoach: best move was a pattern splitter. Lesson: avoid guessing one-by-one in word-family traps.\n\nwirdle.app",
+    "contains_guess_words": false
+  }
+}
+```
+
+The response may include internal category names such as `solid` or `clean`, but it should not include entropy, expected remaining answers, percentile ranks, full candidate lists, exact recommended words, or exact alternative guesses in the default Post Game payload.
+
+### Error Responses
+
+Malformed requests return `400 Bad Request`:
+
+```json
+{
+  "error": "invalid_request",
+  "message": "guess statuses must contain five values"
+}
+```
+
+Incomplete post-game boards return `422 Unprocessable Entity`:
+
+```json
+{
+  "error": "board_incomplete",
+  "message": "Finish the Wordle board before reviewing your game."
+}
+```
+
+Inconsistent boards return `422 Unprocessable Entity`:
+
+```json
+{
+  "error": "board_inconsistent",
+  "message": "This board does not match any possible Wordle answer. Check your tile colors and update the board before getting hints or analysis."
+}
+```
+
+For M1, the UI should show these messages near the board and should not render report cards or share text.
+
+## Domain Model
+
+Add `src/coach.rs` and export it from `src/lib.rs`.
+
+Core structs:
+
+```rust
+pub enum CoachIntent {
+    PostGameReview,
+    EasyHint,
+}
+
+pub enum BoardState {
+    InProgress,
+    Solved { turn: usize },
+    Lost,
+}
+
+pub struct CoachRequest {
+    pub intent: CoachIntent,
+    pub guesses: Vec<GuessInput>,
+    pub hard_mode: bool,
+    pub share_context: Option<ShareContext>,
+}
+
+pub struct BoardAnalysis {
+    pub state: BoardState,
+    pub turns: Vec<TurnAnalysis>,
+    pub final_remaining_candidates: usize,
+}
+
+pub struct TurnAnalysis {
+    pub turn_index: usize,
+    pub guess: Word,
+    pub candidates_before: usize,
+    pub candidates_after: usize,
+    pub information_bucket: InformationBucket,
+    pub constraint_discipline: ConstraintDiscipline,
+    pub move_type: MoveType,
+    pub trap_risk: TrapRisk,
+    pub duplicate_letter_note: DuplicateLetterNote,
+}
+
+pub struct PostGameReport {
+    pub turns: Vec<TurnReview>,
+    pub summary: GameSummary,
+    pub share_text: String,
+}
+```
+
+These names are illustrative; implementation can collapse small enums if that fits the current code style better.
+
+## Board Completion And Consistency
+
+Post Game requires a completed board:
+
+- Solved: any submitted row has all five statuses `correct`.
+- Lost: six submitted rows and none are all-correct.
+- Incomplete: fewer than six submitted rows and no all-correct row.
+
+Validation order:
+
+1. Parse all guesses and statuses.
+2. Reject malformed words/statuses.
+3. Build prefix candidate pools for each turn.
+4. If any prefix has zero candidates, return `board_inconsistent`.
+5. For `post_game_review`, reject `InProgress` as `board_incomplete`.
+6. Generate report only after the board is complete and consistent.
+
+If a solved row appears before later rows, M1 should not silently ignore the extra rows. Treat rows after a solve as invalid request data because a real Wordle game ends at the solve.
+
+## Shared Board Analysis
+
+For each turn, compute from the state before the guess:
+
+- `candidates_before`: candidate solutions matching all prior feedback.
+- `candidates_after`: candidate solutions after adding current feedback.
+- `is_candidate_solve`: whether the actual guess was a possible answer before the turn.
+- `respects_known_info`: whether `is_candidate_consistent(actual_guess, prior_guesses)` is true.
+- `information_value`: how sharply the guess split `candidates_before`.
+- `remaining_guesses`: `6 - turn_index`.
+- `stage`: opener, middle game, endgame, or final guess.
+- `duplicate_letters`: whether repeated letters were present and whether they were useful.
+- `trap_risk`: whether the remaining candidates form a tight family.
+
+Refactor `src/rank.rs` to expose a helper that can score one guess against a candidate pool. Today `rank_information_guesses` computes these values while ranking every legal word. The coach needs the same metrics for the actual played guess without forcing response code to inspect the full Advanced Analyses ranking.
+
+Suggested helper:
+
+```rust
+pub fn evaluate_information_guess(
+    guess: Word,
+    candidates: &[Word],
+    likely_answers: &[LikelyAnswer],
+    past: &PastSolutionIndex,
+) -> InformationGuess
+```
+
+`rank_information_guesses` can call this helper internally.
+
+## Turn Review Heuristics
+
+M1 grades are deterministic heuristic buckets, not an ML model.
+
+### Move Type
+
+- `probe`: not a possible answer, useful for splitting candidates.
+- `solve_attempt`: possible answer before the turn.
+- `forced_solve`: possible answer with few guesses or few candidates left.
+- `constraint_miss`: does not respect known information.
+
+### Information Bucket
+
+Use candidate reduction and information metrics internally, then translate them into language:
+
+- `sharp`: greatly narrows the puzzle.
+- `solid`: meaningfully reduces uncertainty.
+- `modest`: helps but leaves several similar answers alive.
+- `low`: repeats information or barely changes the answer pool.
+
+No numeric metric should appear in the default report text.
+
+### Constraint Discipline
+
+Use prior feedback to detect:
+
+- ignored green positions.
+- misplaced known yellow letters.
+- reused gray letters when duplicate-letter feedback does not justify them.
+- hard-mode violations when `hard_mode` is true.
+
+In normal mode, a constraint miss is not illegal, but the coach should still explain why it was strategically costly.
+
+### Labels
+
+Choose one primary label per turn. M1 should support at least:
+
+- Balanced Opener
+- Vowel-Heavy Opener
+- Constraint Builder
+- Pattern Splitter
+- Candidate Solve
+- Trap Breaker
+- Risky Direct Solve
+- Duplicate-Letter Test
+- Low-Information Repeat
+- Constraint Miss
+
+Label priority:
+
+1. Constraint Miss, if known information was ignored.
+2. Candidate Solve or Risky Direct Solve, if the guess was a possible answer.
+3. Trap Breaker, if it tested a tight word-family pattern.
+4. Duplicate-Letter Test, if repeated letters were strategically relevant.
+5. Pattern Splitter or Constraint Builder, based on information value and stage.
+6. Balanced Opener or Vowel-Heavy Opener for turn 1.
+7. Low-Information Repeat, if no stronger label applies and the information bucket is low.
+
+### Grades
+
+Grade from a weighted score derived from:
+
+- constraint discipline.
+- information bucket.
+- stage appropriateness.
+- whether solve pressure called for an answer-shaped guess.
+- whether the guess was a plausible human word or an obscure legal probe.
+- duplicate-letter usefulness.
+- trap handling.
+
+Suggested mapping:
+
+- `A`: excellent move for the turn context.
+- `B`: reasonable and useful.
+- `C`: understandable but missed a clearer strategic need.
+- `D`: poor information or poor constraint discipline.
+- `F`: severe contradiction with known information.
+
+Use plus/minus for near-boundary cases. Keep grading stable and explainable rather than chasing tiny rank differences.
+
+## Game Summary
+
+Generate:
+
+- best move.
+- most questionable move.
+- biggest information gain.
+- best recovery.
+- missed opportunity, if clear.
+- one lesson for next time.
+
+Selection rules:
+
+- Best move: highest grade, breaking ties by information bucket and later-stage importance.
+- Most questionable move: lowest grade, but avoid calling a forced final guess questionable if it was the only realistic play.
+- Biggest information gain: largest candidate-pool reduction or strongest information bucket.
+- Best recovery: a strong move immediately after a weaker move or after a board state with high trap risk.
+- Missed opportunity: include only when a turn has a clear issue. Do not invent one for a clean game.
+- Lesson: choose the highest-impact repeated theme, such as constraint discipline, switching from probing to solving, trap breaking, or duplicate-letter caution.
+
+The summary should refer to turn numbers and strategy labels, not exact guess words. Share text must not include guess words at all.
+
+## Share Text
+
+Generate share text server-side as part of the coach response so the no-guess-words rule is enforced in one place.
+
+M1 share text includes:
+
+- official-style Wordle result line when possible.
+- official-style grid derived from statuses.
+- `Wirdle: Post Game Mode`.
+- grades.
+- one concise coach sentence.
+- `wirdle.app`.
+
+Rules:
+
+- Never include actual guess words.
+- Never include answer words.
+- Never include candidate lists.
+- Never include exact recommendations.
+- Do not generate share text for incomplete or inconsistent boards.
+- Do not include puzzle number or date in M1 because the UI does not collect them.
+
+Implementation detail: because the repo defaults to ASCII source, keep Unicode square rendering isolated in one small function and test it directly. The rest of the coach logic can stay ASCII-only.
+
+## UI Design
+
+### Main Screen
+
+Keep the Wordle board as the central input.
+
+Add a mode/action area separate from board controls:
+
+- Post Game panel:
+  - primary button: `Review my game`.
+  - disabled until the board is complete.
+  - renders summary, turn timeline, and share button.
+  - report text uses turn numbers and strategy labels rather than guess words.
+- Advanced Analyses panel:
+  - entry button with spoiler warning.
+  - calls `/v1/solve` only after confirmation.
+- Easy Mode:
+  - do not expose a dead hint button in M1.
+  - structure JS state so M2 can add `Get a hint` without changing the board model.
+- Hard Mode:
+  - do not expose a Hard Mode toggle in M1.
+  - send the default `hard_mode: false` value if the client includes the field at all.
+
+### Report Layout
+
+Default report:
+
+1. Overall summary.
+2. Turn timeline.
+3. Share button.
+
+Avoid dense metric tables. Advanced metrics belong behind Advanced Analyses.
+
+### Existing Solver UI
+
+The current Power Words and Answers UI becomes Advanced Analyses. M1 should prevent solver-style results from being the default first screen and should not fetch `/v1/solve` until the user confirms the warning.
+
+## Implementation Plan
+
+1. Add `src/coach.rs`.
+   - Define board state, analysis structs, report structs, and share context.
+   - Build board completion and consistency validation.
+2. Refactor `src/rank.rs`.
+   - Extract `evaluate_information_guess`.
+   - Keep `rank_information_guesses` behavior unchanged.
+3. Implement `analyze_board`.
+   - Compute candidate pools per prefix.
+   - Compute turn-level features.
+4. Implement post-game report generation.
+   - Labels.
+   - grades.
+   - turn text.
+   - game summary.
+5. Implement share text generation.
+   - Result line.
+   - grid.
+   - grades line.
+   - coach sentence.
+6. Add `POST /v1/coach` to `src/server.rs`.
+   - Reuse the existing request parsing approach.
+   - Return structured errors for incomplete and inconsistent boards.
+7. Update `static/index.html`.
+   - Add mode/action area.
+   - Add Review my game flow.
+   - Add report renderer and copy-share behavior.
+   - Gate existing solver UI behind Advanced Analyses warning.
+   - Do not add puzzle metadata inputs or a Hard Mode toggle in M1.
+8. Add focused tests.
+
+## Testing Plan
+
+Rust unit tests:
+
+- solved board is accepted.
+- six-row loss is accepted.
+- incomplete board returns `board_incomplete`.
+- inconsistent board returns `board_inconsistent`.
+- extra rows after solve are rejected.
+- duplicate-letter feedback remains consistent with existing solver behavior.
+- `evaluate_information_guess` matches the same values returned through `rank_information_guesses`.
+- labels and grades are deterministic for fixture games.
+- share text includes grades and grid.
+- share text does not include any submitted guess words.
+
+HTTP tests:
+
+- `POST /v1/coach` parses a valid post-game request.
+- `POST /v1/coach` rejects malformed statuses.
+- `POST /v1/coach` returns `422` for incomplete and inconsistent boards.
+- `POST /v1/solve` behavior is unchanged.
+
+UI checks:
+
+- Review button is disabled until a solved board or six submitted rows.
+- Inconsistent board error appears near the board.
+- Report renders summary before the turn timeline.
+- Share button copies text with no guess words.
+- Share text omits puzzle number and date.
+- No Hard Mode control is shown in the M1 UI.
+- Advanced Analyses warning appears before solver recommendations are shown.
+
+## M2 Compatibility
+
+M2 Easy Mode should reuse:
+
+- `CoachRequest`.
+- `BoardAnalysis`.
+- board consistency validation.
+- stage detection.
+- constraint-discipline notes.
+- trap-risk analysis.
+- duplicate-letter analysis.
+- share generation.
+
+M2 should add:
+
+- `CoachIntent::EasyHint`.
+- `HintRequest`.
+- `HintResponse`.
+- hint level selection.
+- spoiler confirmation flags for Level 5 and Level 6.
+- client-side session tracking for highest hint level used.
+
+The server should remain stateless. The browser can pass `session_context.highest_hint_level_used` back to `/v1/coach` when generating M2 share text. That avoids a session API and keeps M1's share machinery useful for M2.
+
+## Risks And Mitigations
+
+- Heuristic quality may feel generic.
+  - Mitigation: build report text from concrete turn features and add fixture tests for representative games.
+- Duplicate-letter reasoning is easy to explain poorly.
+  - Mitigation: rely on exact feedback simulation for consistency and keep duplicate-letter notes conservative.
+- Manual JSON handling can get brittle as responses grow.
+  - Mitigation: keep request parsing narrow in M1 and centralize JSON escaping/building helpers. Revisit `serde_json` only if M2 response complexity makes manual code risky.
+- Advanced Analyses gating changes the default experience.
+  - Mitigation: preserve existing solver UI and route, but make the warning the entry point.
+- Letter grades can imply false precision.
+  - Mitigation: grade by broad buckets and pair every grade with plain-language reasoning.
+
+## Open Questions
+
+- None for M1.


### PR DESCRIPTION
## Summary

- Adds the Wirdle v2 M1 post-game coaching layer and POST /v1/coach endpoint.
- Refactors one-guess information evaluation so coach analysis reuses the existing solver scoring path.
- Updates the Wirdle UI so Post Game is the primary flow and Advanced Analyses is behind a spoiler warning.
- Generates server-side share text with wirdle.onrender.com and without submitted guess words.

## Validation

- cargo fmt
- cargo test passed with 21 tests.
- Manual local HTTP checks against recent puzzle solutions: broil, sepia, and quell.

## Notes

The working tree had unrelated parent-directory changes outside wirdle; this PR intentionally includes only the Wirdle v2 M1 implementation files.