### PR TITLE
[codex] Implement Wirdle v2 M2 hints

### DIFF
--- a/wirdle/src/coach.rs
+++ b/wirdle/src/coach.rs
@@ -3,6 +3,8 @@ use crate::filter::{GuessInput, filter_candidates, is_candidate_consistent};
 use crate::rank::evaluate_information_guess;
 use crate::rank::{InformationGuess, rank_likely_answers};
 use crate::solver::{PastSolutionPolicy, Solver};
+use crate::word::Word;
+use std::collections::HashMap;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum CoachIntent {
@@ -32,6 +34,21 @@ pub struct CoachRequest {
     pub intent: CoachIntent,
     pub guesses: Vec<GuessInput>,
     pub hard_mode: bool,
+    pub hint_request: Option<HintRequest>,
+    pub session_context: Option<SessionContext>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct HintRequest {
+    pub requested_level: Option<u8>,
+    pub explain_current: bool,
+    pub confirmed_spoiler: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct SessionContext {
+    pub highest_hint_level_used: u8,
+    pub hint_levels_used: Vec<u8>,
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]
@@ -146,6 +163,7 @@ pub struct CoachResponse {
     pub intent: CoachIntent,
     pub board: BoardSummary,
     pub post_game: Option<PostGameReport>,
+    pub easy_hint: Option<HintResponse>,
     pub share: Option<ShareOutput>,
 }
 
@@ -193,6 +211,122 @@ pub struct ShareOutput {
     pub contains_guess_words: bool,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub enum HintLevel {
+    GentleNudge = 1,
+    NextMoveStrategy = 2,
+    UsefulLetter = 3,
+    Pattern = 4,
+    StrongGuessHelp = 5,
+    AnswerReveal = 6,
+}
+
+impl HintLevel {
+    fn from_requested(value: u8) -> Self {
+        match value.clamp(1, 6) {
+            1 => Self::GentleNudge,
+            2 => Self::NextMoveStrategy,
+            3 => Self::UsefulLetter,
+            4 => Self::Pattern,
+            5 => Self::StrongGuessHelp,
+            _ => Self::AnswerReveal,
+        }
+    }
+
+    fn as_u8(self) -> u8 {
+        self as u8
+    }
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::GentleNudge => "Gentle Nudge",
+            Self::NextMoveStrategy => "Next-Move Strategy",
+            Self::UsefulLetter => "Useful Letter",
+            Self::Pattern => "Pattern",
+            Self::StrongGuessHelp => "Strong Guess Help",
+            Self::AnswerReveal => "Answer Reveal",
+        }
+    }
+
+    fn next_action_label(self) -> Option<&'static str> {
+        match self {
+            Self::GentleNudge => Some("A little more"),
+            Self::NextMoveStrategy => Some("Show useful letters"),
+            Self::UsefulLetter => Some("Show a pattern"),
+            Self::Pattern => Some("Help me choose"),
+            Self::StrongGuessHelp => Some("Reveal answer"),
+            Self::AnswerReveal => None,
+        }
+    }
+
+    fn spoiler_risk(self) -> SpoilerRisk {
+        match self {
+            Self::GentleNudge => SpoilerRisk::Low,
+            Self::NextMoveStrategy => SpoilerRisk::LowMedium,
+            Self::UsefulLetter => SpoilerRisk::MediumHigh,
+            Self::Pattern => SpoilerRisk::High,
+            Self::StrongGuessHelp => SpoilerRisk::VeryHigh,
+            Self::AnswerReveal => SpoilerRisk::Complete,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SpoilerRisk {
+    Low,
+    LowMedium,
+    MediumHigh,
+    High,
+    VeryHigh,
+    Complete,
+}
+
+impl SpoilerRisk {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Low => "low",
+            Self::LowMedium => "low_medium",
+            Self::MediumHigh => "medium_high",
+            Self::High => "high",
+            Self::VeryHigh => "very_high",
+            Self::Complete => "complete",
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct HintResponse {
+    pub level: HintLevel,
+    pub label: &'static str,
+    pub spoiler_risk: SpoilerRisk,
+    pub message: String,
+    pub rationale: Option<String>,
+    pub next_action_label: Option<&'static str>,
+    pub requires_confirmation_for_next: bool,
+    pub revealed_words: Vec<Word>,
+    pub share_summary: HintShareSummary,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct HintShareSummary {
+    pub highest_hint_level_used: u8,
+    pub hint_labels_used: Vec<String>,
+}
+
+#[derive(Clone, Debug)]
+struct KnownYellow {
+    letter: u8,
+    blocked_positions: Vec<usize>,
+}
+
+#[derive(Clone, Debug)]
+struct HintGuessOption {
+    word: Word,
+    information: InformationGuess,
+    human_score: i32,
+    explanation: String,
+}
+
 #[derive(Clone, Debug)]
 pub struct CoachError {
     pub code: &'static str,
@@ -211,10 +345,7 @@ impl CoachError {
 pub fn coach(solver: &Solver, request: &CoachRequest) -> Result<CoachResponse, CoachError> {
     match request.intent {
         CoachIntent::PostGameReview => post_game_review(solver, request),
-        CoachIntent::EasyHint => Err(CoachError::new(
-            "unsupported_intent",
-            "Easy Mode hints are not implemented in Milestone 1.",
-        )),
+        CoachIntent::EasyHint => easy_hint(solver, request),
     }
 }
 
@@ -327,7 +458,12 @@ fn post_game_review(solver: &Solver, request: &CoachRequest) -> Result<CoachResp
     }
 
     let report = build_post_game_report(&analysis);
-    let share_text = build_share_text(&analysis, &report);
+    let hint_summary = hint_share_summary(request.session_context.as_ref(), None);
+    let share_text = build_post_game_share_text(
+        &analysis,
+        &report,
+        (hint_summary.highest_hint_level_used > 0).then_some(&hint_summary),
+    );
     let contains_guess_words = request
         .guesses
         .iter()
@@ -341,6 +477,76 @@ fn post_game_review(solver: &Solver, request: &CoachRequest) -> Result<CoachResp
             remaining_candidates: analysis.final_remaining_candidates,
         },
         post_game: Some(report),
+        easy_hint: None,
+        share: Some(ShareOutput {
+            text: share_text,
+            contains_guess_words,
+        }),
+    })
+}
+
+fn easy_hint(solver: &Solver, request: &CoachRequest) -> Result<CoachResponse, CoachError> {
+    let analysis = analyze_board(solver, &request.guesses, request.hard_mode)?;
+    if analysis.state != BoardState::InProgress {
+        return Err(CoachError::new(
+            "game_finished",
+            "This Wordle is already complete. Switch to Post Game for a review.",
+        ));
+    }
+
+    let candidates = current_candidates(solver, &request.guesses);
+    if candidates.is_empty() {
+        return Err(board_inconsistent());
+    }
+
+    let hint_level = choose_hint_level(
+        &analysis,
+        request.hint_request.as_ref(),
+        request.session_context.as_ref(),
+    );
+    let hint_request = request.hint_request.as_ref().cloned().unwrap_or_default();
+    if matches!(
+        hint_level,
+        HintLevel::StrongGuessHelp | HintLevel::AnswerReveal
+    ) && !hint_request.confirmed_spoiler
+    {
+        return Err(CoachError::new(
+            "spoiler_confirmation_required",
+            "This hint can reveal answer-like words. Confirm that you want a stronger hint.",
+        ));
+    }
+    if hint_level == HintLevel::AnswerReveal && candidates.len() != 1 {
+        return Err(CoachError::new(
+            "answer_reveal_unavailable",
+            "Wirdle cannot identify one exact answer from this board yet. Ask for strong guess help instead.",
+        ));
+    }
+
+    let hint = build_hint_response(
+        solver,
+        request,
+        &analysis,
+        &candidates,
+        hint_level,
+        hint_request.explain_current,
+    );
+    let share_text = build_easy_share_text(&analysis, &hint.share_summary);
+    let contains_guess_words = request
+        .guesses
+        .iter()
+        .map(|guess| guess.word)
+        .chain(hint.revealed_words.iter().copied())
+        .any(|word| share_text.to_lowercase().contains(word.as_str()));
+
+    Ok(CoachResponse {
+        intent: request.intent,
+        board: BoardSummary {
+            state: analysis.state.clone(),
+            turns: analysis.turns.len(),
+            remaining_candidates: analysis.final_remaining_candidates,
+        },
+        post_game: None,
+        easy_hint: Some(hint),
         share: Some(ShareOutput {
             text: share_text,
             contains_guess_words,
@@ -469,7 +675,11 @@ fn lesson(turns: &[TurnReview]) -> String {
         .to_string()
 }
 
-fn build_share_text(analysis: &BoardAnalysis, report: &PostGameReport) -> String {
+fn build_post_game_share_text(
+    analysis: &BoardAnalysis,
+    report: &PostGameReport,
+    hint_summary: Option<&HintShareSummary>,
+) -> String {
     let result = match analysis.state {
         BoardState::Solved { turn } => format!("Wordle {turn}/6"),
         BoardState::Lost => "Wordle X/6".to_string(),
@@ -485,9 +695,699 @@ fn build_share_text(analysis: &BoardAnalysis, report: &PostGameReport) -> String
     let best = report.summary.best_move_turn;
     let lesson = &report.summary.lesson;
 
+    if let Some(summary) = hint_summary {
+        let hints = summary.hint_labels_used.join(", ");
+        return format!(
+            "{result}\n{grid}\n\nWirdle: Easy Mode + Post Game Mode\nHints: {hints}\nHighest hint: Level {}\nGrades: {grades}\nCoach: best move was turn {best}. Lesson: {lesson}\n\nwirdle.onrender.com",
+            summary.highest_hint_level_used
+        );
+    }
+
     format!(
         "{result}\n{grid}\n\nWirdle: Post Game Mode\nGrades: {grades}\nCoach: best move was turn {best}. Lesson: {lesson}\n\nwirdle.onrender.com"
     )
+}
+
+fn build_easy_share_text(analysis: &BoardAnalysis, summary: &HintShareSummary) -> String {
+    let result = match analysis.state {
+        BoardState::Solved { turn } => format!("Wordle {turn}/6"),
+        BoardState::Lost => "Wordle X/6".to_string(),
+        BoardState::InProgress => "Wordle ?/6".to_string(),
+    };
+    let grid = analysis
+        .turns
+        .iter()
+        .map(|turn| status_grid_row(&turn.statuses))
+        .collect::<Vec<_>>()
+        .join("\n");
+    let hints = summary.hint_labels_used.join(", ");
+
+    format!(
+        "{result}\n{grid}\n\nWirdle: Easy Mode\nHints: {hints}\nHighest hint: Level {}\nCoach: helped me use the clues without giving it away.\n\nwirdle.onrender.com",
+        summary.highest_hint_level_used
+    )
+}
+
+fn choose_hint_level(
+    analysis: &BoardAnalysis,
+    hint_request: Option<&HintRequest>,
+    session_context: Option<&SessionContext>,
+) -> HintLevel {
+    if let Some(request) = hint_request {
+        if request.explain_current {
+            if let Some(level) = request.requested_level {
+                return HintLevel::from_requested(level);
+            }
+            if let Some(session) = session_context {
+                if session.highest_hint_level_used > 0 {
+                    return HintLevel::from_requested(session.highest_hint_level_used);
+                }
+            }
+        }
+        if let Some(level) = request.requested_level {
+            let requested = HintLevel::from_requested(level);
+            if matches!(requested, HintLevel::UsefulLetter | HintLevel::Pattern)
+                && should_downgrade_spoilery_mid_hint(analysis)
+            {
+                return HintLevel::NextMoveStrategy;
+            }
+            return requested;
+        }
+    }
+
+    first_hint_level(analysis)
+}
+
+fn first_hint_level(analysis: &BoardAnalysis) -> HintLevel {
+    let Some(last_turn) = analysis.turns.last() else {
+        return HintLevel::GentleNudge;
+    };
+    if last_turn.constraint_discipline == ConstraintDiscipline::Miss {
+        return HintLevel::GentleNudge;
+    }
+    if analysis.turns.len() <= 3 && analysis.final_remaining_candidates > 20 {
+        return HintLevel::GentleNudge;
+    }
+    if last_turn.trap_risk != TrapRisk::Low || analysis.final_remaining_candidates <= 12 {
+        return HintLevel::NextMoveStrategy;
+    }
+    HintLevel::GentleNudge
+}
+
+fn should_downgrade_spoilery_mid_hint(analysis: &BoardAnalysis) -> bool {
+    analysis.turns.len() <= 1 && analysis.final_remaining_candidates > 80
+}
+
+fn build_hint_response(
+    solver: &Solver,
+    request: &CoachRequest,
+    analysis: &BoardAnalysis,
+    candidates: &[Word],
+    level: HintLevel,
+    explain_current: bool,
+) -> HintResponse {
+    let (message, base_rationale, revealed_words) = match level {
+        HintLevel::GentleNudge => (
+            gentle_nudge_message(analysis, &request.guesses, request.hard_mode),
+            gentle_nudge_rationale(analysis),
+            Vec::new(),
+        ),
+        HintLevel::NextMoveStrategy => (
+            next_move_strategy_message(analysis, &request.guesses, candidates),
+            next_move_strategy_rationale(analysis),
+            Vec::new(),
+        ),
+        HintLevel::UsefulLetter => (
+            useful_letter_message(candidates, &request.guesses),
+            Some("These letters appear often in the remaining answer-shaped pool, while avoiding letters you have already tested.".to_string()),
+            Vec::new(),
+        ),
+        HintLevel::Pattern => (
+            pattern_hint(candidates, &request.guesses).unwrap_or_else(|| {
+                "The structure is still too open for a clean pattern; keep the confirmed positions fixed and test a new slot.".to_string()
+            }),
+            Some("The pattern only uses information implied by the board and shared structure across compatible answers.".to_string()),
+            Vec::new(),
+        ),
+        HintLevel::StrongGuessHelp => {
+            let options = human_like_guess_options(solver, candidates, &request.guesses, request.hard_mode);
+            let revealed_words = options.iter().take(3).map(|option| option.word).collect::<Vec<_>>();
+            let message = if revealed_words.len() <= 1 {
+                "This is the strongest answer-shaped direction I would consider from the current board.".to_string()
+            } else {
+                "Here are a few plausible directions. They all respect what you know, but they test different uncertainties.".to_string()
+            };
+            let rationale = options.first().map(|option| {
+                format!(
+                    "The leading option is still answer-shaped and has a {:.1}-bit information profile for this board. {}",
+                    option.information.entropy_bits,
+                    option.explanation
+                )
+            });
+            (message, rationale, revealed_words)
+        }
+        HintLevel::AnswerReveal => (
+            "The board now points to one compatible answer.".to_string(),
+            Some("Wirdle can reveal this only because the entered feedback leaves exactly one compatible candidate.".to_string()),
+            candidates.first().copied().into_iter().collect(),
+        ),
+    };
+    let rationale = if explain_current {
+        Some(expanded_rationale(
+            level,
+            analysis,
+            base_rationale.as_deref(),
+        ))
+    } else {
+        base_rationale
+    };
+    let share_summary = hint_share_summary(request.session_context.as_ref(), Some(level));
+
+    HintResponse {
+        level,
+        label: level.label(),
+        spoiler_risk: level.spoiler_risk(),
+        message,
+        rationale,
+        next_action_label: level.next_action_label(),
+        requires_confirmation_for_next: matches!(
+            level,
+            HintLevel::Pattern | HintLevel::StrongGuessHelp
+        ),
+        revealed_words,
+        share_summary,
+    }
+}
+
+fn gentle_nudge_message(
+    analysis: &BoardAnalysis,
+    guesses: &[GuessInput],
+    hard_mode: bool,
+) -> String {
+    if guesses.is_empty() {
+        return "Start with a broad opener that mixes common consonants and vowels.".to_string();
+    }
+    if analysis
+        .turns
+        .iter()
+        .any(|turn| turn.constraint_discipline == ConstraintDiscipline::Miss)
+    {
+        return if hard_mode {
+            "Hard Mode means the next playable guess must carry every confirmed clue forward."
+                .to_string()
+        } else {
+            "Before choosing the next word, check that every green and yellow clue is still being used.".to_string()
+        };
+    }
+    let yellow_letters = known_yellow_letters(guesses);
+    if yellow_letters.len() > 1 {
+        let clues = yellow_letters
+            .iter()
+            .take(3)
+            .map(|yellow| {
+                format!(
+                    "{} away from {}",
+                    letter_name(yellow.letter),
+                    blocked_positions_phrase(&yellow.blocked_positions)
+                )
+            })
+            .collect::<Vec<_>>();
+        return format!("Place the yellow clues: {}.", clues.join("; "));
+    }
+    if let Some(yellow) = yellow_letters.first() {
+        return format!(
+            "Focus on moving the yellow {} away from {}.",
+            letter_name(yellow.letter),
+            blocked_positions_phrase(&yellow.blocked_positions)
+        );
+    }
+    if let Some((idx, letter)) = known_green_positions(guesses).first() {
+        return format!(
+            "Keep the {} green {} fixed while you learn something new.",
+            position_name(*idx),
+            letter_name(*letter)
+        );
+    }
+    if guessed_vowel_count(guesses) >= 4 {
+        return "Most vowel information is already on the board. Common consonants matter more now."
+            .to_string();
+    }
+    if analysis
+        .turns
+        .last()
+        .is_some_and(|turn| turn.trap_risk != TrapRisk::Low)
+    {
+        return "This looks like a pattern trap; avoid guessing similar answers one by one."
+            .to_string();
+    }
+    "This is a narrowing turn: make the next guess explain more of the board.".to_string()
+}
+
+fn gentle_nudge_rationale(analysis: &BoardAnalysis) -> Option<String> {
+    let turns = analysis.turns.len();
+    if turns == 0 {
+        return Some("With no colors entered yet, broad coverage is more useful than committing to a narrow answer shape.".to_string());
+    }
+    Some(format!(
+        "After {turns} turn{}, there are still {} compatible answers, so the next move should be guided by the clues already earned.",
+        if turns == 1 { "" } else { "s" },
+        analysis.final_remaining_candidates
+    ))
+}
+
+fn next_move_strategy_message(
+    analysis: &BoardAnalysis,
+    guesses: &[GuessInput],
+    candidates: &[Word],
+) -> String {
+    if guesses.is_empty() {
+        return "Choose an opener that tests several common letters without repeating a letter."
+            .to_string();
+    }
+    if analysis
+        .turns
+        .last()
+        .is_some_and(|turn| turn.trap_risk == TrapRisk::High)
+    {
+        return "A pattern-splitting guess is more useful than trying similar answers one at a time."
+            .to_string();
+    }
+    if analysis.final_remaining_candidates <= 3 || analysis.turns.len() >= 5 {
+        return "With the board this narrow, prefer a plausible answer that respects every clue."
+            .to_string();
+    }
+    if let Some(yellow) = known_yellow_letters(guesses).first() {
+        return format!(
+            "Try a guess that moves the yellow {} into a new position while testing fresh consonants.",
+            letter_name(yellow.letter)
+        );
+    }
+    if let Some((idx, letter)) = known_green_positions(guesses).first() {
+        return format!(
+            "Look for a plausible answer that keeps the {} green {} and tests new letters.",
+            position_name(*idx),
+            letter_name(*letter)
+        );
+    }
+    if let Some(idx) = important_unknown_positions(candidates, guesses).first() {
+        return format!(
+            "The biggest uncertainty is the {} position; make the next guess teach you about that slot.",
+            position_name(*idx)
+        );
+    }
+    "Look for a guess that stays answer-shaped while testing letters you have not learned about yet."
+        .to_string()
+}
+
+fn next_move_strategy_rationale(analysis: &BoardAnalysis) -> Option<String> {
+    if analysis.final_remaining_candidates <= 12 {
+        return Some("The candidate pool is small enough that answer-shaped guesses matter more than pure information probes.".to_string());
+    }
+    if analysis
+        .turns
+        .last()
+        .is_some_and(|turn| turn.trap_risk != TrapRisk::Low)
+    {
+        return Some("Several compatible answers likely share a tight structure, so separating the changing position is valuable.".to_string());
+    }
+    Some(
+        "This keeps the hint about the purpose of the move, without naming the move itself."
+            .to_string(),
+    )
+}
+
+fn useful_letter_message(candidates: &[Word], guesses: &[GuessInput]) -> String {
+    let letters = useful_remaining_letters(candidates, guesses);
+    if letters.is_empty() {
+        return "The most useful new information is likely from an untested common consonant."
+            .to_string();
+    }
+    format!("Testing {} would be useful.", letter_list(&letters))
+}
+
+fn expanded_rationale(
+    level: HintLevel,
+    analysis: &BoardAnalysis,
+    base_rationale: Option<&str>,
+) -> String {
+    let base = base_rationale.unwrap_or("This hint follows directly from the board state.");
+    match level {
+        HintLevel::GentleNudge | HintLevel::NextMoveStrategy => format!(
+            "{base} The board has {} compatible answer{} after {} entered turn{}, so the goal is to reduce uncertainty without giving away an answer.",
+            analysis.final_remaining_candidates,
+            if analysis.final_remaining_candidates == 1 {
+                ""
+            } else {
+                "s"
+            },
+            analysis.turns.len(),
+            if analysis.turns.len() == 1 { "" } else { "s" }
+        ),
+        HintLevel::UsefulLetter => format!(
+            "{base} Letter hints are stronger because they introduce information that may not already be visible on your board."
+        ),
+        HintLevel::Pattern => format!(
+            "{base} Pattern hints are intentionally spoilery, so this keeps at least one unresolved slot hidden."
+        ),
+        HintLevel::StrongGuessHelp => {
+            format!(
+                "{base} These words are shown only after confirmation because they can materially reduce the puzzle."
+            )
+        }
+        HintLevel::AnswerReveal => {
+            format!("{base} No ranking model is being treated as secret answer knowledge.")
+        }
+    }
+}
+
+fn hint_share_summary(
+    session_context: Option<&SessionContext>,
+    current_level: Option<HintLevel>,
+) -> HintShareSummary {
+    let mut levels = session_context
+        .map(|session| session.hint_levels_used.clone())
+        .unwrap_or_default();
+    if let Some(session) = session_context {
+        if levels.is_empty() && session.highest_hint_level_used > 0 {
+            levels.push(session.highest_hint_level_used);
+        }
+    }
+    if let Some(level) = current_level {
+        levels.push(level.as_u8());
+    }
+    levels.retain(|level| (1..=6).contains(level));
+    levels.sort_unstable();
+    levels.dedup();
+    let highest = levels
+        .iter()
+        .copied()
+        .max()
+        .unwrap_or(0)
+        .max(session_context.map_or(0, |session| session.highest_hint_level_used));
+    let hint_labels_used = levels
+        .iter()
+        .copied()
+        .map(|level| HintLevel::from_requested(level).label().to_string())
+        .collect();
+
+    HintShareSummary {
+        highest_hint_level_used: highest,
+        hint_labels_used,
+    }
+}
+
+fn current_candidates(solver: &Solver, guesses: &[GuessInput]) -> Vec<Word> {
+    filter_candidates(&solver.lexicon().candidate_solutions, guesses)
+}
+
+fn known_green_positions(guesses: &[GuessInput]) -> Vec<(usize, u8)> {
+    let mut positions = Vec::new();
+    for guess in guesses {
+        for (idx, status) in guess.statuses.iter().enumerate() {
+            if *status == LetterStatus::Correct {
+                let value = (idx, guess.word.0[idx]);
+                if !positions.contains(&value) {
+                    positions.push(value);
+                }
+            }
+        }
+    }
+    positions.sort_unstable();
+    positions
+}
+
+fn known_yellow_letters(guesses: &[GuessInput]) -> Vec<KnownYellow> {
+    let mut blocked: HashMap<u8, Vec<usize>> = HashMap::new();
+    for guess in guesses {
+        for (idx, status) in guess.statuses.iter().enumerate() {
+            if *status == LetterStatus::Present {
+                let entry = blocked.entry(guess.word.0[idx]).or_default();
+                if !entry.contains(&idx) {
+                    entry.push(idx);
+                }
+            }
+        }
+    }
+    let mut yellows = blocked
+        .into_iter()
+        .map(|(letter, mut blocked_positions)| {
+            blocked_positions.sort_unstable();
+            KnownYellow {
+                letter,
+                blocked_positions,
+            }
+        })
+        .collect::<Vec<_>>();
+    yellows.sort_by_key(|yellow| yellow.letter);
+    yellows
+}
+
+fn known_absent_letters(guesses: &[GuessInput]) -> Vec<u8> {
+    let mut confirmed = [false; 26];
+    let mut absent = [false; 26];
+    for guess in guesses {
+        for (idx, status) in guess.statuses.iter().enumerate() {
+            let letter = usize::from(guess.word.0[idx] - b'a');
+            match status {
+                LetterStatus::Correct | LetterStatus::Present => confirmed[letter] = true,
+                LetterStatus::Absent => absent[letter] = true,
+            }
+        }
+    }
+    absent
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, value)| (*value && !confirmed[idx]).then_some(b'a' + idx as u8))
+        .collect()
+}
+
+fn important_unknown_positions(candidates: &[Word], guesses: &[GuessInput]) -> Vec<usize> {
+    let greens = known_green_positions(guesses);
+    let mut positions = (0..5)
+        .filter(|idx| !greens.iter().any(|(green_idx, _)| green_idx == idx))
+        .map(|idx| {
+            let mut seen = [false; 26];
+            for candidate in candidates {
+                seen[usize::from(candidate.0[idx] - b'a')] = true;
+            }
+            let count = seen.iter().filter(|value| **value).count();
+            (idx, count)
+        })
+        .collect::<Vec<_>>();
+    positions.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    positions.into_iter().map(|(idx, _)| idx).collect()
+}
+
+fn useful_remaining_letters(candidates: &[Word], guesses: &[GuessInput]) -> Vec<u8> {
+    let mut guessed = [false; 26];
+    for guess in guesses {
+        for letter in guess.word.letters() {
+            guessed[letter] = true;
+        }
+    }
+    for letter in known_absent_letters(guesses) {
+        guessed[usize::from(letter - b'a')] = true;
+    }
+
+    let mut counts = [0usize; 26];
+    for candidate in candidates {
+        let mut seen_in_word = [false; 26];
+        for letter in candidate.letters() {
+            if !guessed[letter] {
+                seen_in_word[letter] = true;
+            }
+        }
+        for (idx, seen) in seen_in_word.iter().enumerate() {
+            if *seen {
+                counts[idx] += 1;
+            }
+        }
+    }
+    let minimum = if candidates.len() <= 8 { 1 } else { 2 };
+    let mut letters = counts
+        .iter()
+        .enumerate()
+        .filter_map(|(idx, count)| (*count >= minimum).then_some((b'a' + idx as u8, *count)))
+        .collect::<Vec<_>>();
+    letters.sort_by(|a, b| b.1.cmp(&a.1).then_with(|| a.0.cmp(&b.0)));
+    letters
+        .into_iter()
+        .take(3)
+        .map(|(letter, _)| letter)
+        .collect()
+}
+
+fn pattern_hint(candidates: &[Word], guesses: &[GuessInput]) -> Option<String> {
+    if candidates.is_empty() {
+        return None;
+    }
+
+    let mut pattern = [None; 5];
+    for (idx, letter) in known_green_positions(guesses) {
+        pattern[idx] = Some(letter);
+    }
+    let green_count = pattern.iter().filter(|letter| letter.is_some()).count();
+    let mut shared_positions = (0..5)
+        .filter(|idx| pattern[*idx].is_none())
+        .filter_map(|idx| {
+            let first = candidates[0].0[idx];
+            let shared = candidates.iter().all(|word| word.0[idx] == first);
+            shared.then_some((idx, first))
+        })
+        .collect::<Vec<_>>();
+    shared_positions.sort_unstable();
+    if green_count + shared_positions.len() < 5 {
+        if let Some((idx, letter)) = shared_positions.first().copied() {
+            pattern[idx] = Some(letter);
+        }
+    }
+
+    let pattern_text = format_pattern(&pattern);
+    if pattern.iter().all(|letter| letter.is_some()) {
+        return Some(
+            "The structure is fully determined; use answer reveal if you want Wirdle to name it."
+                .to_string(),
+        );
+    }
+
+    if let Some((start, letters)) = common_edge_pattern(candidates) {
+        if letters.len() >= 2 {
+            let edge = if start == 0 { "opening" } else { "ending" };
+            return Some(format!(
+                "A useful answer-shaped pattern is `{pattern_text}`. The {edge} is doing a lot of work."
+            ));
+        }
+    }
+
+    Some(format!(
+        "A useful answer-shaped pattern is `{pattern_text}`."
+    ))
+}
+
+fn common_edge_pattern(candidates: &[Word]) -> Option<(usize, Vec<u8>)> {
+    for width in (2..=4).rev() {
+        for start in [0, 5 - width] {
+            let first = &candidates.first()?.0[start..start + width];
+            let same = candidates
+                .iter()
+                .filter(|word| &word.0[start..start + width] == first)
+                .count();
+            if same >= 2 && same * 2 >= candidates.len() {
+                return Some((start, first.to_vec()));
+            }
+        }
+    }
+    None
+}
+
+fn human_like_guess_options(
+    solver: &Solver,
+    candidates: &[Word],
+    guesses: &[GuessInput],
+    hard_mode: bool,
+) -> Vec<HintGuessOption> {
+    let likely_answers = rank_likely_answers(
+        candidates,
+        solver.past(),
+        &PastSolutionPolicy::default(),
+        &solver.lexicon().overrides,
+    );
+    let likely_scores: HashMap<Word, f64> = likely_answers
+        .iter()
+        .map(|answer| (answer.word, answer.score))
+        .collect();
+    let mut options = candidates
+        .iter()
+        .copied()
+        .filter(|word| !hard_mode || is_candidate_consistent(*word, guesses))
+        .map(|word| {
+            let information =
+                evaluate_information_guess(word, candidates, &likely_answers, solver.past());
+            let likely_score = likely_scores.get(&word).copied().unwrap_or(0.0);
+            let mut human_score = 100;
+            human_score += (likely_score * 70.0).round() as i32;
+            human_score += (information.entropy_bits * 12.0).round() as i32;
+            human_score -= (information.expected_remaining * 2.0).round() as i32;
+            if information.used_before {
+                human_score -= 25;
+            }
+            let explanation = if information.used_before {
+                "It is compatible, but it has appeared before in the loaded answer history."
+                    .to_string()
+            } else if candidates.len() <= 4 {
+                "The board is narrow enough that a direct answer-shaped option is reasonable."
+                    .to_string()
+            } else {
+                "It balances answer plausibility with useful separation of the remaining pool."
+                    .to_string()
+            };
+            HintGuessOption {
+                word,
+                information,
+                human_score,
+                explanation,
+            }
+        })
+        .collect::<Vec<_>>();
+    options.sort_by(|a, b| {
+        b.human_score
+            .cmp(&a.human_score)
+            .then_with(|| b.information.score.total_cmp(&a.information.score))
+            .then_with(|| a.word.cmp(&b.word))
+    });
+    options
+}
+
+fn format_pattern(pattern: &[Option<u8>; 5]) -> String {
+    pattern
+        .iter()
+        .map(|letter| letter.map(letter_name).unwrap_or_else(|| "_".to_string()))
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn letter_name(letter: u8) -> String {
+    char::from(letter).to_ascii_uppercase().to_string()
+}
+
+fn letter_list(letters: &[u8]) -> String {
+    match letters {
+        [] => String::new(),
+        [one] => letter_name(*one),
+        [one, two] => format!("{} or {}", letter_name(*one), letter_name(*two)),
+        _ => {
+            let mut names = letters
+                .iter()
+                .map(|letter| letter_name(*letter))
+                .collect::<Vec<_>>();
+            let last = names.pop().expect("at least one letter");
+            format!("{}, or {}", names.join(", "), last)
+        }
+    }
+}
+
+fn blocked_positions_phrase(positions: &[usize]) -> String {
+    let names = positions
+        .iter()
+        .map(|idx| position_name(*idx))
+        .collect::<Vec<_>>();
+    match names.as_slice() {
+        [] => "its known bad position".to_string(),
+        [one] => format!("the {one} position"),
+        [one, two] => format!("the {one} or {two} position"),
+        _ => {
+            let last = names.last().expect("at least one position");
+            let prefix = names[..names.len() - 1].join(", ");
+            format!("{prefix}, or {last} position")
+        }
+    }
+}
+
+fn position_name(idx: usize) -> &'static str {
+    match idx {
+        0 => "first",
+        1 => "second",
+        2 => "third",
+        3 => "fourth",
+        _ => "fifth",
+    }
+}
+
+fn guessed_vowel_count(guesses: &[GuessInput]) -> usize {
+    let mut vowels = [false; 5];
+    for guess in guesses {
+        for letter in guess.word.0 {
+            match letter {
+                b'a' => vowels[0] = true,
+                b'e' => vowels[1] = true,
+                b'i' => vowels[2] = true,
+                b'o' => vowels[3] = true,
+                b'u' => vowels[4] = true,
+                _ => {}
+            }
+        }
+    }
+    vowels.iter().filter(|seen| **seen).count()
 }
 
 pub fn status_grid_row(statuses: &[LetterStatus; 5]) -> String {
@@ -871,16 +1771,22 @@ pub fn coach_response_json(response: &CoachResponse) -> String {
         .as_ref()
         .map(post_game_json)
         .unwrap_or_else(|| "null".to_string());
+    let easy_hint = response
+        .easy_hint
+        .as_ref()
+        .map(hint_response_json)
+        .unwrap_or_else(|| "null".to_string());
     let share = response
         .share
         .as_ref()
         .map(share_json)
         .unwrap_or_else(|| "null".to_string());
     format!(
-        "{{\"intent\":\"{}\",\"board\":{},\"post_game\":{},\"share\":{}}}",
+        "{{\"intent\":\"{}\",\"board\":{},\"post_game\":{},\"easy_hint\":{},\"share\":{}}}",
         response.intent.as_str(),
         board_json(&response.board),
         post_game,
+        easy_hint,
         share
     )
 }
@@ -959,6 +1865,49 @@ fn share_json(share: &ShareOutput) -> String {
         "{{\"text\":\"{}\",\"contains_guess_words\":{}}}",
         escape_json(&share.text),
         share.contains_guess_words
+    )
+}
+
+fn hint_response_json(hint: &HintResponse) -> String {
+    let rationale = hint
+        .rationale
+        .as_ref()
+        .map(|value| format!("\"{}\"", escape_json(value)))
+        .unwrap_or_else(|| "null".to_string());
+    let next_action_label = hint
+        .next_action_label
+        .map(|value| format!("\"{}\"", escape_json(value)))
+        .unwrap_or_else(|| "null".to_string());
+    let revealed_words = hint
+        .revealed_words
+        .iter()
+        .map(|word| format!("\"{}\"", word))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"level\":{},\"label\":\"{}\",\"spoiler_risk\":\"{}\",\"message\":\"{}\",\"rationale\":{},\"next_action_label\":{},\"requires_confirmation_for_next\":{},\"revealed_words\":[{}],\"share_summary\":{}}}",
+        hint.level.as_u8(),
+        hint.label,
+        hint.spoiler_risk.as_str(),
+        escape_json(&hint.message),
+        rationale,
+        next_action_label,
+        hint.requires_confirmation_for_next,
+        revealed_words,
+        hint_share_summary_json(&hint.share_summary)
+    )
+}
+
+fn hint_share_summary_json(summary: &HintShareSummary) -> String {
+    let labels = summary
+        .hint_labels_used
+        .iter()
+        .map(|label| format!("\"{}\"", escape_json(label)))
+        .collect::<Vec<_>>()
+        .join(",");
+    format!(
+        "{{\"highest_hint_level_used\":{},\"hint_labels_used\":[{}]}}",
+        summary.highest_hint_level_used, labels
     )
 }
 

--- a/wirdle/src/server.rs
+++ b/wirdle/src/server.rs
@@ -1,4 +1,6 @@
-use crate::coach::{CoachIntent, CoachRequest, coach, coach_response_json};
+use crate::coach::{
+    CoachIntent, CoachRequest, HintRequest, SessionContext, coach, coach_response_json,
+};
 use crate::feedback::LetterStatus;
 use crate::filter::GuessInput;
 use crate::solver::{PastSolutionPolicy, SolveMode, SolveRequest, SolveResponse, Solver};
@@ -163,7 +165,52 @@ pub fn parse_coach_request(json: &str) -> Result<CoachRequest, String> {
         intent,
         guesses: solve_request.guesses,
         hard_mode: json_bool(json, "hard_mode").unwrap_or(false),
+        hint_request: parse_hint_request(json)?,
+        session_context: parse_session_context(json)?,
     })
+}
+
+fn parse_hint_request(json: &str) -> Result<Option<HintRequest>, String> {
+    let Some(object) = json_object(json, "hint_request")? else {
+        return Ok(None);
+    };
+    let requested_level = if json_has_key(object, "requested_level") {
+        Some(
+            json_number(object, "requested_level")
+                .ok_or("hint_request.requested_level must be a number")?
+                .clamp(1, 6) as u8,
+        )
+    } else {
+        None
+    };
+
+    Ok(Some(HintRequest {
+        requested_level,
+        explain_current: json_bool(object, "explain_current").unwrap_or(false),
+        confirmed_spoiler: json_bool(object, "confirmed_spoiler").unwrap_or(false),
+    }))
+}
+
+fn parse_session_context(json: &str) -> Result<Option<SessionContext>, String> {
+    let Some(object) = json_object(json, "session_context")? else {
+        return Ok(None);
+    };
+    let highest_hint_level_used = json_number(object, "highest_hint_level_used")
+        .unwrap_or(0)
+        .clamp(0, 6) as u8;
+    let hint_levels_used = if json_has_key(object, "hint_levels_used") {
+        json_number_array(object, "hint_levels_used")?
+            .into_iter()
+            .map(|level| level.clamp(1, 6) as u8)
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    Ok(Some(SessionContext {
+        highest_hint_level_used,
+        hint_levels_used,
+    }))
 }
 
 pub fn parse_solve_request(json: &str) -> Result<SolveRequest, String> {
@@ -309,6 +356,56 @@ fn json_string_array(object: &str, key: &str) -> Vec<String> {
         .map(|part| part.trim().trim_matches('"').to_string())
         .filter(|part| !part.is_empty())
         .collect()
+}
+
+fn json_number_array(object: &str, key: &str) -> Result<Vec<u64>, String> {
+    let Some(key_start) = object.find(&format!("\"{key}\"")) else {
+        return Ok(Vec::new());
+    };
+    let Some(open_rel) = object[key_start..].find('[') else {
+        return Err(format!("{key} must be an array"));
+    };
+    let open = key_start + open_rel;
+    let Some(close) = matching(object, open, '[', ']') else {
+        return Err(format!("{key} array is not closed"));
+    };
+    let inner = object[open + 1..close].trim();
+    if inner.is_empty() {
+        return Ok(Vec::new());
+    }
+    inner
+        .split(',')
+        .map(|part| {
+            part.trim()
+                .parse::<u64>()
+                .map_err(|_| format!("{key} must contain only numbers"))
+        })
+        .collect()
+}
+
+fn json_object<'a>(object: &'a str, key: &str) -> Result<Option<&'a str>, String> {
+    let Some(key_start) = object.find(&format!("\"{key}\"")) else {
+        return Ok(None);
+    };
+    let Some(colon_rel) = object[key_start..].find(':') else {
+        return Err(format!("{key} is malformed"));
+    };
+    let after_colon = key_start + colon_rel + 1;
+    let value_start = object[after_colon..]
+        .char_indices()
+        .find_map(|(idx, ch)| (!ch.is_whitespace()).then_some(after_colon + idx))
+        .ok_or_else(|| format!("{key} is missing a value"))?;
+    if !object[value_start..].starts_with('{') {
+        return Err(format!("{key} must be an object"));
+    }
+    let Some(close) = matching(object, value_start, '{', '}') else {
+        return Err(format!("{key} object is not closed"));
+    };
+    Ok(Some(&object[value_start..=close]))
+}
+
+fn json_has_key(object: &str, key: &str) -> bool {
+    object.find(&format!("\"{key}\"")).is_some()
 }
 
 fn json_bool(object: &str, key: &str) -> Option<bool> {

--- a/wirdle/static/index.html
+++ b/wirdle/static/index.html
@@ -346,6 +346,103 @@
         gap: 12px;
       }
 
+      .hint-shell {
+        display: grid;
+        gap: 10px;
+      }
+
+      .hint-shell[hidden],
+      .easy-share[hidden] {
+        display: none;
+      }
+
+      .hint-card {
+        display: grid;
+        gap: 10px;
+        border: 1px solid var(--line);
+        border-radius: 8px;
+        background: #fbfaf7;
+        padding: 12px;
+      }
+
+      .hint-meta {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 10px;
+      }
+
+      .hint-label {
+        font-size: 13px;
+        font-weight: 800;
+        color: var(--accent);
+      }
+
+      .hint-risk {
+        color: var(--muted);
+        font-size: 12px;
+        white-space: nowrap;
+      }
+
+      .hint-message,
+      .hint-rationale {
+        margin: 0;
+        color: var(--ink);
+        font-size: 14px;
+        line-height: 1.4;
+      }
+
+      .hint-rationale {
+        color: var(--muted);
+      }
+
+      .revealed-words {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 6px;
+      }
+
+      .revealed-word {
+        border: 1px solid var(--accent);
+        border-radius: 6px;
+        background: var(--accent-soft);
+        color: var(--accent);
+        padding: 5px 8px;
+        font-weight: 800;
+        letter-spacing: 0;
+        text-transform: uppercase;
+      }
+
+      .hint-actions,
+      .easy-share {
+        display: grid;
+        grid-template-columns: 1fr 1fr;
+        gap: 8px;
+      }
+
+      .toggle-row {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: 12px;
+        color: var(--muted);
+        font-size: 14px;
+      }
+
+      .toggle-label {
+        display: inline-flex;
+        align-items: center;
+        gap: 8px;
+        color: var(--ink);
+        font-weight: 700;
+      }
+
+      .toggle-label input {
+        width: 18px;
+        height: 18px;
+        accent-color: var(--accent);
+      }
+
       .summary-band {
         display: grid;
         gap: 6px;
@@ -454,6 +551,10 @@
 
       .mode-tabs .tab-option {
         grid-template-columns: minmax(0, 1fr);
+      }
+
+      .tabs.mode-tabs {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
       }
 
       .tab-option:has(.tab-button[aria-selected="true"]) {
@@ -784,10 +885,23 @@
             <div class="tab-option">
               <button
                 class="tab-button mode-tab-button"
-                id="mode-post-game"
+                id="mode-easy"
                 type="button"
                 role="tab"
                 aria-selected="true"
+                aria-controls="easyModePanel"
+                data-mode="easy"
+              >
+                Easy Mode
+              </button>
+            </div>
+            <div class="tab-option">
+              <button
+                class="tab-button mode-tab-button"
+                id="mode-post-game"
+                type="button"
+                role="tab"
+                aria-selected="false"
                 aria-controls="postGamePanel"
                 data-mode="post-game"
               >
@@ -811,9 +925,42 @@
 
           <section
             class="mode-panel primary-panel"
+            id="easyModePanel"
+            role="tabpanel"
+            aria-labelledby="mode-easy"
+          >
+            <div class="section-heading">
+              <h2>Easy Mode</h2>
+              <div class="ranking-note" id="easyModeState">Live help</div>
+            </div>
+            <div class="toggle-row">
+              <label class="toggle-label">
+                <input id="easyHardMode" type="checkbox" />
+                Hard Mode
+              </label>
+            </div>
+            <button class="action-button primary" id="getHint" type="button">
+              Get a hint
+            </button>
+            <div
+              class="hint-shell"
+              id="hintCard"
+              aria-live="polite"
+              hidden
+            ></div>
+            <div class="easy-share" id="easyShare" hidden>
+              <button class="action-button" id="copyEasyShare" type="button">
+                Copy share text
+              </button>
+            </div>
+          </section>
+
+          <section
+            class="mode-panel"
             id="postGamePanel"
             role="tabpanel"
             aria-labelledby="mode-post-game"
+            hidden
           >
             <div class="section-heading">
               <h2>Post Game</h2>
@@ -913,9 +1060,16 @@
       const message = document.querySelector("#message");
       const recommendations = document.querySelector("#recommendations");
       const rankingNote = document.querySelector("#rankingNote");
+      const easyModeState = document.querySelector("#easyModeState");
+      const easyModePanel = document.querySelector("#easyModePanel");
       const postGameState = document.querySelector("#postGameState");
       const postGamePanel = document.querySelector("#postGamePanel");
       const advancedPanel = document.querySelector("#advancedPanel");
+      const getHintButton = document.querySelector("#getHint");
+      const easyHardMode = document.querySelector("#easyHardMode");
+      const hintCard = document.querySelector("#hintCard");
+      const easyShare = document.querySelector("#easyShare");
+      const copyEasyShareButton = document.querySelector("#copyEasyShare");
       const reviewGameButton = document.querySelector("#reviewGame");
       const coachReport = document.querySelector("#coachReport");
       const showAdvancedButton = document.querySelector("#showAdvanced");
@@ -950,6 +1104,14 @@
       let advancedConfirmed = false;
       let latestCoachId = 0;
       let latestShareText = "";
+      let latestHintId = 0;
+      let latestHintData = null;
+      let highestHintLevelUsed = 0;
+      let hintLevelsUsed = [];
+      let pendingHintLevel = null;
+      let easyModeHardMode = false;
+      let latestEasyShareText = "";
+      let hintRequestInFlight = false;
 
       function setMessage(text, isError = false) {
         message.textContent = text;
@@ -994,13 +1156,55 @@
         coachReport.innerHTML = "";
       }
 
+      function clearEasyHintState({ preserveUsage = false } = {}) {
+        latestHintId += 1;
+        latestHintData = null;
+        if (!preserveUsage) {
+          highestHintLevelUsed = 0;
+          hintLevelsUsed = [];
+        }
+        pendingHintLevel = null;
+        latestEasyShareText = "";
+        hintRequestInFlight = false;
+        hintCard.hidden = true;
+        hintCard.innerHTML = "";
+        easyShare.hidden = true;
+        syncEasyModeState();
+      }
+
       function setActiveMode(mode) {
         modeTabButtons.forEach((button) => {
           const isSelected = button.dataset.mode === mode;
           button.setAttribute("aria-selected", String(isSelected));
         });
+        easyModePanel.hidden = mode !== "easy";
         postGamePanel.hidden = mode !== "post-game";
         advancedPanel.hidden = mode !== "advanced";
+        easyModePanel.classList.toggle("primary-panel", mode === "easy");
+        postGamePanel.classList.toggle("primary-panel", mode === "post-game");
+        advancedPanel.classList.toggle("primary-panel", mode === "advanced");
+      }
+
+      function syncEasyModeState() {
+        const complete = isBoardComplete();
+        getHintButton.disabled = complete || hintRequestInFlight;
+        if (complete) {
+          easyModeState.textContent = "Game complete";
+          getHintButton.textContent = "Get a hint";
+          return;
+        }
+        if (hintRequestInFlight) {
+          easyModeState.textContent = "Thinking";
+          getHintButton.textContent = "Getting hint...";
+          return;
+        }
+        if (latestHintData) {
+          easyModeState.textContent = `Level ${latestHintData.level}`;
+          getHintButton.textContent = "Get a hint";
+          return;
+        }
+        easyModeState.textContent = "Live help";
+        getHintButton.textContent = "Get a hint";
       }
 
       function syncPostGameState() {
@@ -1060,6 +1264,7 @@
           "How Wirdle Helps",
           `
             <p>Wirdle does not know today&apos;s answer. Play a guess in Wordle, add that same word here, then tap the tiles to match Wordle&apos;s colors.</p>
+            <p><strong>Easy Mode</strong> gives live hints that get stronger only when you ask.</p>
             <p><strong>Post Game</strong> reviews a finished board with grades, turn notes, and share text.</p>
             <p><strong>Advanced Analyses</strong> keeps the old solver-style rankings behind a spoiler warning.</p>
           `,
@@ -1117,6 +1322,7 @@
           submitted.statuses[tileIndex] =
             statuses[(current + 1) % statuses.length];
           clearCoachReport();
+          clearEasyHintState();
           renderBoard();
           refreshRecommendations();
           focusKeyboard();
@@ -1144,6 +1350,7 @@
           activeLetters.length !== WORD_LENGTH;
         syncKeyboardCapture();
         syncPostGameState();
+        syncEasyModeState();
       }
 
       function addLetter(letter) {
@@ -1185,6 +1392,7 @@
         });
         activeLetters = [];
         clearCoachReport();
+        clearEasyHintState({ preserveUsage: true });
         renderBoard();
         refreshRecommendations();
         setMessage("");
@@ -1469,6 +1677,158 @@
         coachReport.hidden = false;
       }
 
+      function spoilerRiskLabel(value) {
+        return String(value || "")
+          .split("_")
+          .map(titleCase)
+          .join(" ");
+      }
+
+      function renderEasyHint(data) {
+        const hint = data.easy_hint;
+        latestHintData = hint;
+        latestEasyShareText = data.share?.text || "";
+        highestHintLevelUsed = Math.max(
+          highestHintLevelUsed,
+          hint.share_summary?.highest_hint_level_used || hint.level,
+        );
+        if (!hintLevelsUsed.includes(hint.level)) {
+          hintLevelsUsed.push(hint.level);
+          hintLevelsUsed.sort((a, b) => a - b);
+        }
+
+        const rationale = hint.rationale
+          ? `<p class="hint-rationale">${escapeHtml(hint.rationale)}</p>`
+          : "";
+        const revealedWords = hint.revealed_words?.length
+          ? `<div class="revealed-words">${hint.revealed_words
+              .map(
+                (word) =>
+                  `<span class="revealed-word">${escapeHtml(word)}</span>`,
+              )
+              .join("")}</div>`
+          : "";
+        const stronger = hint.next_action_label
+          ? `<button class="action-button primary" id="strongerHint" type="button">${escapeHtml(hint.next_action_label)}</button>`
+          : "";
+        const explain = `<button class="action-button" id="explainHint" type="button">Explain that</button>`;
+
+        hintCard.innerHTML = `
+          <article class="hint-card">
+            <div class="hint-meta">
+              <div class="hint-label">Level ${hint.level}: ${escapeHtml(hint.label)}</div>
+              <div class="hint-risk">${escapeHtml(spoilerRiskLabel(hint.spoiler_risk))}</div>
+            </div>
+            <p class="hint-message">${escapeHtml(hint.message)}</p>
+            ${revealedWords}
+            ${rationale}
+            <div class="hint-actions">
+              ${stronger}
+              ${explain}
+            </div>
+          </article>
+        `;
+        hintCard.hidden = false;
+        easyShare.hidden = !latestEasyShareText;
+        syncEasyModeState();
+      }
+
+      function openHintWarning(level, explainCurrent = false) {
+        const isReveal = level >= 6;
+        openOverlay(
+          isReveal ? "Reveal answer?" : "Stronger hint?",
+          isReveal
+            ? "<p>This can reveal the answer if your board narrows to one compatible word.</p>"
+            : "<p>This can reveal answer-like words and reduce the puzzle.</p>",
+          "hint-spoiler",
+          isReveal ? "Reveal answer" : "Show stronger hint",
+          () => {
+            requestHint({
+              requestedLevel: level,
+              explainCurrent,
+              confirmedSpoiler: true,
+            });
+          },
+        );
+      }
+
+      async function requestHint({
+        requestedLevel = null,
+        explainCurrent = false,
+        confirmedSpoiler = false,
+      } = {}) {
+        if (isBoardComplete()) {
+          setMessage("This game is complete. Use Post Game for a review.", true);
+          syncEasyModeState();
+          return;
+        }
+        const hintId = latestHintId + 1;
+        latestHintId = hintId;
+        pendingHintLevel = requestedLevel;
+        hintRequestInFlight = true;
+        syncEasyModeState();
+        setMessage("");
+
+        const hintRequest = {};
+        if (requestedLevel !== null) {
+          hintRequest.requested_level = requestedLevel;
+        }
+        if (explainCurrent) {
+          hintRequest.explain_current = true;
+          if (hintRequest.requested_level === undefined && latestHintData) {
+            hintRequest.requested_level = latestHintData.level;
+          }
+        }
+        if (confirmedSpoiler) {
+          hintRequest.confirmed_spoiler = true;
+        }
+
+        try {
+          const response = await fetch("/v1/coach", {
+            method: "POST",
+            headers: { "content-type": "application/json" },
+            body: JSON.stringify({
+              intent: "easy_hint",
+              guesses: submittedGuesses,
+              hard_mode: easyModeHardMode,
+              hint_request: hintRequest,
+              session_context: {
+                highest_hint_level_used: highestHintLevelUsed,
+                hint_levels_used: hintLevelsUsed,
+              },
+            }),
+          });
+          const data = await response.json();
+          if (hintId !== latestHintId) {
+            return;
+          }
+          if (!response.ok) {
+            if (data.error === "spoiler_confirmation_required") {
+              openHintWarning(
+                requestedLevel || Math.min((latestHintData?.level || 4) + 1, 6),
+                explainCurrent,
+              );
+              setMessage("");
+              return;
+            }
+            setMessage(data.message || "Hint unavailable.", true);
+            return;
+          }
+          renderEasyHint(data);
+          setMessage("");
+        } catch (_err) {
+          if (hintId === latestHintId) {
+            setMessage("Hint unavailable.", true);
+          }
+        } finally {
+          if (hintId === latestHintId) {
+            hintRequestInFlight = false;
+            pendingHintLevel = null;
+            syncEasyModeState();
+          }
+        }
+      }
+
       async function reviewGame() {
         if (!isBoardComplete()) {
           setMessage("Finish the Wordle board before reviewing your game.", true);
@@ -1488,6 +1848,10 @@
               intent: "post_game_review",
               guesses: submittedGuesses,
               hard_mode: false,
+              session_context: {
+                highest_hint_level_used: highestHintLevelUsed,
+                hint_levels_used: hintLevelsUsed,
+              },
             }),
           });
           const data = await response.json();
@@ -1640,6 +2004,7 @@
       undoButton.addEventListener("click", () => {
         submittedGuesses.pop();
         clearCoachReport();
+        clearEasyHintState();
         renderBoard();
         refreshRecommendations();
         focusKeyboard();
@@ -1649,12 +2014,21 @@
         submittedGuesses.length = 0;
         activeLetters = [];
         clearCoachReport();
+        clearEasyHintState();
         renderBoard();
         refreshRecommendations();
         focusKeyboard();
       });
 
       dataInfo.addEventListener("click", openDataInfo);
+      getHintButton.addEventListener("click", () => {
+        requestHint();
+      });
+      easyHardMode.addEventListener("change", () => {
+        easyModeHardMode = easyHardMode.checked;
+        clearEasyHintState();
+        setMessage("");
+      });
       reviewGameButton.addEventListener("click", reviewGame);
       showAdvancedButton.addEventListener("click", openAdvancedWarning);
       coachHelp.addEventListener("click", () => {
@@ -1683,6 +2057,20 @@
         button.addEventListener("click", () => {
           setActiveMode(button.dataset.mode);
         });
+      });
+
+      hintCard.addEventListener("click", (event) => {
+        if (event.target.closest("#strongerHint")) {
+          const nextLevel = Math.min((latestHintData?.level || 0) + 1, 6);
+          requestHint({ requestedLevel: nextLevel });
+          return;
+        }
+        if (event.target.closest("#explainHint")) {
+          requestHint({
+            requestedLevel: latestHintData?.level || highestHintLevelUsed || 1,
+            explainCurrent: true,
+          });
+        }
       });
 
       tabButtons.forEach((button) => {
@@ -1716,6 +2104,19 @@
         }
         try {
           await navigator.clipboard.writeText(latestShareText);
+          setMessage("Share text copied.");
+        } catch (_err) {
+          setMessage("Share text could not be copied.", true);
+        }
+      });
+
+      copyEasyShareButton.addEventListener("click", async () => {
+        if (!latestEasyShareText) {
+          setMessage("Share text unavailable.", true);
+          return;
+        }
+        try {
+          await navigator.clipboard.writeText(latestEasyShareText);
           setMessage("Share text copied.");
         } catch (_err) {
           setMessage("Share text could not be copied.", true);

--- a/wirdle/tests/core.rs
+++ b/wirdle/tests/core.rs
@@ -1,4 +1,6 @@
-use wordle_api::coach::{CoachIntent, CoachRequest, coach, status_grid_row};
+use wordle_api::coach::{
+    CoachIntent, CoachRequest, HintLevel, HintRequest, SessionContext, coach, status_grid_row,
+};
 use wordle_api::feedback::{LetterStatus::*, pattern_from_statuses, statuses_from_pattern};
 use wordle_api::filter::GuessInput;
 use wordle_api::rank::{evaluate_information_guess, rank_information_guesses, rank_likely_answers};
@@ -29,6 +31,34 @@ fn played_game(answer: &str, guesses: &[&str]) -> Vec<GuessInput> {
             )
         })
         .collect()
+}
+
+fn coach_request(intent: CoachIntent, guesses: Vec<GuessInput>) -> CoachRequest {
+    CoachRequest {
+        intent,
+        guesses,
+        hard_mode: false,
+        hint_request: None,
+        session_context: None,
+    }
+}
+
+fn easy_hint_request(
+    guesses: Vec<GuessInput>,
+    requested_level: Option<u8>,
+    confirmed_spoiler: bool,
+) -> CoachRequest {
+    CoachRequest {
+        intent: CoachIntent::EasyHint,
+        guesses,
+        hard_mode: false,
+        hint_request: Some(HintRequest {
+            requested_level,
+            explain_current: false,
+            confirmed_spoiler,
+        }),
+        session_context: None,
+    }
 }
 
 #[test]
@@ -224,6 +254,8 @@ fn post_game_coach_accepts_solved_board_and_omits_guess_words_from_share() {
             intent: CoachIntent::PostGameReview,
             guesses: guesses.clone(),
             hard_mode: false,
+            hint_request: None,
+            session_context: None,
         },
     )
     .unwrap();
@@ -254,6 +286,8 @@ fn post_game_coach_accepts_six_row_loss() {
             intent: CoachIntent::PostGameReview,
             guesses,
             hard_mode: false,
+            hint_request: None,
+            session_context: None,
         },
     )
     .unwrap();
@@ -271,6 +305,8 @@ fn post_game_coach_rejects_incomplete_and_inconsistent_boards() {
             intent: CoachIntent::PostGameReview,
             guesses: played_game("visit", &["slate"]),
             hard_mode: false,
+            hint_request: None,
+            session_context: None,
         },
     )
     .unwrap_err();
@@ -285,6 +321,8 @@ fn post_game_coach_rejects_incomplete_and_inconsistent_boards() {
                 [Present, Present, Present, Present, Present],
             )],
             hard_mode: false,
+            hint_request: None,
+            session_context: None,
         },
     )
     .unwrap_err();
@@ -301,11 +339,273 @@ fn post_game_coach_rejects_rows_after_solve() {
             intent: CoachIntent::PostGameReview,
             guesses,
             hard_mode: false,
+            hint_request: None,
+            session_context: None,
         },
     )
     .unwrap_err();
 
     assert_eq!(err.code, "invalid_request");
+}
+
+#[test]
+fn easy_hint_accepts_in_progress_board_and_starts_low() {
+    let solver = fixture_solver();
+    let response = coach(
+        &solver,
+        &coach_request(
+            CoachIntent::EasyHint,
+            played_game("visit", &["slate", "crown"]),
+        ),
+    )
+    .unwrap();
+    let hint = response.easy_hint.as_ref().unwrap();
+    let share = response.share.as_ref().unwrap();
+
+    assert_eq!(response.intent, CoachIntent::EasyHint);
+    assert!(hint.level <= HintLevel::NextMoveStrategy);
+    assert!(hint.revealed_words.is_empty());
+    assert!(share.text.starts_with("Wordle ?/6"));
+    assert!(share.text.contains("Wirdle: Easy Mode"));
+    assert!(!share.contains_guess_words);
+}
+
+#[test]
+fn easy_hint_rejects_bad_or_finished_boards() {
+    let solver = fixture_solver();
+    let inconsistent = coach(
+        &solver,
+        &coach_request(
+            CoachIntent::EasyHint,
+            vec![GuessInput::new(
+                word("slate"),
+                [Present, Present, Present, Present, Present],
+            )],
+        ),
+    )
+    .unwrap_err();
+    assert_eq!(inconsistent.code, "board_inconsistent");
+
+    let rows_after_solve = coach(
+        &solver,
+        &coach_request(
+            CoachIntent::EasyHint,
+            played_game("visit", &["visit", "couch"]),
+        ),
+    )
+    .unwrap_err();
+    assert_eq!(rows_after_solve.code, "invalid_request");
+
+    let solved = coach(
+        &solver,
+        &coach_request(CoachIntent::EasyHint, played_game("visit", &["visit"])),
+    )
+    .unwrap_err();
+    assert_eq!(solved.code, "game_finished");
+
+    let lost = coach(
+        &solver,
+        &coach_request(
+            CoachIntent::EasyHint,
+            played_game(
+                "couch",
+                &["slate", "pride", "brink", "flame", "gypsy", "zonal"],
+            ),
+        ),
+    )
+    .unwrap_err();
+    assert_eq!(lost.code, "game_finished");
+}
+
+#[test]
+fn easy_hint_escalates_and_explain_current_does_not_advance() {
+    let solver = fixture_solver();
+    let guesses = played_game("visit", &["slate", "crown"]);
+    let stronger = CoachRequest {
+        intent: CoachIntent::EasyHint,
+        guesses: guesses.clone(),
+        hard_mode: false,
+        hint_request: Some(HintRequest {
+            requested_level: Some(2),
+            explain_current: false,
+            confirmed_spoiler: false,
+        }),
+        session_context: Some(SessionContext {
+            highest_hint_level_used: 1,
+            hint_levels_used: vec![1],
+        }),
+    };
+    let response = coach(&solver, &stronger).unwrap();
+    let hint = response.easy_hint.as_ref().unwrap();
+    assert_eq!(hint.level, HintLevel::NextMoveStrategy);
+    assert_eq!(hint.share_summary.highest_hint_level_used, 2);
+    assert!(
+        hint.share_summary
+            .hint_labels_used
+            .contains(&"Gentle Nudge".to_string())
+    );
+
+    let explain = CoachRequest {
+        hint_request: Some(HintRequest {
+            requested_level: Some(1),
+            explain_current: true,
+            confirmed_spoiler: false,
+        }),
+        session_context: Some(SessionContext {
+            highest_hint_level_used: 1,
+            hint_levels_used: vec![1],
+        }),
+        ..stronger
+    };
+    let response = coach(&solver, &explain).unwrap();
+    let hint = response.easy_hint.as_ref().unwrap();
+    assert_eq!(hint.level, HintLevel::GentleNudge);
+    assert_eq!(hint.share_summary.highest_hint_level_used, 1);
+    assert!(hint.rationale.as_ref().unwrap().contains("compatible"));
+}
+
+#[test]
+fn easy_hint_spoiler_levels_are_gated_and_share_safe() {
+    let solver = fixture_solver();
+    let guesses = played_game("visit", &["slate", "crown"]);
+
+    let level_five =
+        coach(&solver, &easy_hint_request(guesses.clone(), Some(5), false)).unwrap_err();
+    assert_eq!(level_five.code, "spoiler_confirmation_required");
+
+    let level_six =
+        coach(&solver, &easy_hint_request(guesses.clone(), Some(6), false)).unwrap_err();
+    assert_eq!(level_six.code, "spoiler_confirmation_required");
+
+    let response = coach(&solver, &easy_hint_request(guesses, Some(5), true)).unwrap();
+    let hint = response.easy_hint.as_ref().unwrap();
+    let share = response.share.as_ref().unwrap();
+    assert_eq!(hint.level, HintLevel::StrongGuessHelp);
+    assert!(!hint.revealed_words.is_empty());
+    assert!(hint.revealed_words.len() <= 3);
+    for word in &hint.revealed_words {
+        assert!(!share.text.to_lowercase().contains(word.as_str()));
+    }
+    assert!(!share.contains_guess_words);
+}
+
+#[test]
+fn answer_reveal_requires_one_compatible_candidate() {
+    let solver = fixture_solver();
+    let too_many = coach(
+        &solver,
+        &easy_hint_request(played_game("visit", &["slate"]), Some(6), true),
+    )
+    .unwrap_err();
+    assert_eq!(too_many.code, "answer_reveal_unavailable");
+
+    let guesses = single_candidate_in_progress_game(&solver, "visit");
+    let response = coach(&solver, &easy_hint_request(guesses, Some(6), true)).unwrap();
+    let hint = response.easy_hint.as_ref().unwrap();
+    assert_eq!(hint.level, HintLevel::AnswerReveal);
+    assert_eq!(hint.revealed_words, vec![word("visit")]);
+    assert!(!response.share.as_ref().unwrap().text.contains("visit"));
+}
+
+#[test]
+fn useful_letters_and_pattern_hints_do_not_reveal_words() {
+    let solver = fixture_solver();
+    let guesses = played_game("couch", &["slate", "pride"]);
+
+    let letters = coach(&solver, &easy_hint_request(guesses.clone(), Some(3), false)).unwrap();
+    let letter_hint = letters.easy_hint.as_ref().unwrap();
+    assert_eq!(letter_hint.level, HintLevel::UsefulLetter);
+    assert!(letter_hint.revealed_words.is_empty());
+    assert!(!letter_hint.message.contains("couch"));
+
+    let pattern = coach(&solver, &easy_hint_request(guesses, Some(4), false)).unwrap();
+    let pattern_hint = pattern.easy_hint.as_ref().unwrap();
+    assert_eq!(pattern_hint.level, HintLevel::Pattern);
+    assert!(pattern_hint.revealed_words.is_empty());
+    assert!(!pattern_hint.message.contains("couch"));
+}
+
+#[test]
+fn hard_mode_strong_hint_options_respect_known_constraints() {
+    let solver = fixture_solver();
+    let guesses = played_game("visit", &["slate", "crown"]);
+    let request = CoachRequest {
+        intent: CoachIntent::EasyHint,
+        guesses: guesses.clone(),
+        hard_mode: true,
+        hint_request: Some(HintRequest {
+            requested_level: Some(5),
+            explain_current: false,
+            confirmed_spoiler: true,
+        }),
+        session_context: None,
+    };
+    let response = coach(&solver, &request).unwrap();
+    let hint = response.easy_hint.as_ref().unwrap();
+
+    assert!(!hint.revealed_words.is_empty());
+    assert!(
+        hint.revealed_words
+            .iter()
+            .all(|word| wordle_api::is_candidate_consistent(*word, &guesses))
+    );
+}
+
+#[test]
+fn post_game_share_includes_easy_mode_usage() {
+    let solver = fixture_solver();
+    let request = CoachRequest {
+        intent: CoachIntent::PostGameReview,
+        guesses: played_game("visit", &["slate", "crown", "visit"]),
+        hard_mode: false,
+        hint_request: None,
+        session_context: Some(SessionContext {
+            highest_hint_level_used: 2,
+            hint_levels_used: vec![1, 2],
+        }),
+    };
+    let response = coach(&solver, &request).unwrap();
+    let share = response.share.as_ref().unwrap();
+
+    assert!(share.text.contains("Wirdle: Easy Mode + Post Game Mode"));
+    assert!(share.text.contains("Highest hint: Level 2"));
+    assert!(share.text.contains("Grades:"));
+    assert!(!share.contains_guess_words);
+}
+
+fn single_candidate_in_progress_game(solver: &Solver, answer: &str) -> Vec<GuessInput> {
+    let answer = word(answer);
+    let mut observed = Vec::new();
+    for _ in 0..5 {
+        let candidates = filter_candidates(&solver.lexicon().candidate_solutions, &observed);
+        if candidates == vec![answer] {
+            return observed;
+        }
+        let guess = solver
+            .lexicon()
+            .candidate_solutions
+            .iter()
+            .copied()
+            .filter(|candidate| *candidate != answer)
+            .min_by_key(|candidate| {
+                let mut trial = observed.clone();
+                trial.push(GuessInput::new(
+                    *candidate,
+                    statuses_from_pattern(evaluate_feedback(*candidate, answer)),
+                ));
+                filter_candidates(&solver.lexicon().candidate_solutions, &trial).len()
+            })
+            .expect("candidate guess");
+        observed.push(GuessInput::new(
+            guess,
+            statuses_from_pattern(evaluate_feedback(guess, answer)),
+        ));
+    }
+    assert_eq!(
+        filter_candidates(&solver.lexicon().candidate_solutions, &observed),
+        vec![answer]
+    );
+    observed
 }
 
 #[test]
@@ -371,6 +671,64 @@ fn parses_and_handles_coach_http_request() {
     assert_eq!(content_type, "application/json");
     assert!(response.contains("\"post_game\""));
     assert!(response.contains("wirdle.onrender.com"));
+}
+
+#[test]
+fn parses_and_handles_easy_hint_http_request() {
+    let body = r#"{
+      "intent": "easy_hint",
+      "guesses": [{"word": "slate", "statuses": ["present", "absent", "absent", "present", "absent"]}],
+      "hard_mode": false,
+      "hint_request": {"requested_level": 2},
+      "session_context": {"highest_hint_level_used": 1, "hint_levels_used": [1]}
+    }"#;
+    let parsed = parse_coach_request(body).unwrap();
+    assert_eq!(parsed.intent, CoachIntent::EasyHint);
+    assert_eq!(parsed.hint_request.unwrap().requested_level, Some(2));
+    assert_eq!(parsed.session_context.unwrap().hint_levels_used, vec![1]);
+
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let (status, content_type, response) = handle_http_request(&request, &fixture_solver());
+    assert_eq!(status, "200 OK");
+    assert_eq!(content_type, "application/json");
+    assert!(response.contains("\"easy_hint\""));
+    assert!(response.contains("\"level\":2"));
+    assert!(response.contains("Highest hint: Level 2"));
+}
+
+#[test]
+fn easy_hint_http_rejects_malformed_request_and_missing_confirmation() {
+    let malformed = r#"{
+      "intent": "easy_hint",
+      "guesses": [],
+      "hint_request": {"requested_level": "strong"}
+    }"#;
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        malformed.len(),
+        malformed
+    );
+    let (status, _, response) = handle_http_request(&request, &fixture_solver());
+    assert_eq!(status, "400 Bad Request");
+    assert!(response.contains("requested_level must be a number"));
+
+    let gated = r#"{
+      "intent": "easy_hint",
+      "guesses": [{"word": "slate", "statuses": ["present", "absent", "absent", "present", "absent"]}],
+      "hint_request": {"requested_level": 5}
+    }"#;
+    let request = format!(
+        "POST /v1/coach HTTP/1.1\r\ncontent-length: {}\r\n\r\n{}",
+        gated.len(),
+        gated
+    );
+    let (status, _, response) = handle_http_request(&request, &fixture_solver());
+    assert_eq!(status, "422 Unprocessable Entity");
+    assert!(response.contains("spoiler_confirmation_required"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- Implements the M2 Easy Mode hint ladder on the existing /v1/coach endpoint.
- Adds hint/session request parsing, spoiler gates, answer-reveal constraints, and Easy Mode/Post Game share summaries.
- Wires the UI for the default Easy Mode tab, hint card, stronger/explain flows, Hard Mode toggle, and Easy Mode share copy.
- Adds Rust and HTTP coverage for the hint ladder, malformed requests, share safety, and hard-mode strong hint behavior.

## Validation

- cargo test (31 passed)
- Browser reload against http://127.0.0.1:7878: Easy Mode selected, Hard Mode visible, hint button enabled, no console errors.
- Manual HTTP play-throughs for recent local puzzle solutions: BROIL (2026-06-15), SEPIA (2026-06-14), and QUELL (2026-06-13).

## Notes

- The M2 design doc is present on this branch as wirdle-v2-m2-design.md.
- Known follow-up: the current UI copy buttons keep per-mode latest share text; a future patch should unify share copy behavior so it always reflects full Easy Mode + Post Game usage when both have been used.