### PR TITLE
Add SVG icon asset, serve it from the server, and use it in the UI header

### DIFF
--- a/wirdle/src/server.rs
+++ b/wirdle/src/server.rs
@@ -89,6 +89,13 @@ pub fn handle_http_request(raw: &str, solver: &Solver) -> (&'static str, &'stati
             include_str!("../static/index.html").to_string(),
         );
     }
+    if first.starts_with("GET /wirdle-icon.svg ") {
+        return (
+            "200 OK",
+            "image/svg+xml",
+            include_str!("../static/wirdle-icon.svg").to_string(),
+        );
+    }
     if first.starts_with("GET /v1/health ") {
         return ("200 OK", "application/json", solver.health_json());
     }

--- a/wirdle/static/index.html
+++ b/wirdle/static/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Wirdle - Wordle Coach</title>
+    <link rel="icon" type="image/svg+xml" href="/wirdle-icon.svg" />
     <style>
       :root {
         --bg: #f7f7f3;
@@ -67,8 +68,22 @@
       h1 {
         margin: 0;
         font-size: 24px;
+        font-weight: 800;
         line-height: 1;
         letter-spacing: 0;
+      }
+
+      .brand {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.08em;
+      }
+
+      .brand-icon {
+        display: block;
+        width: 1em;
+        height: 1em;
+        flex: 0 0 auto;
       }
 
       .header-tools {
@@ -792,7 +807,7 @@
   <body>
     <main>
       <header>
-        <h1>Wirdle</h1>
+        <h1 class="brand" aria-label="Wirdle"><img class="brand-icon" src="/wirdle-icon.svg" alt="W" />irdle</h1>
         <div class="header-tools">
           <button
             class="header-info-button"

--- a/wirdle/static/wirdle-icon.svg
+++ b/wirdle/static/wirdle-icon.svg
@@ -1,0 +1,24 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-labelledby="title desc">
+  <title id="title">Wirdle icon</title>
+  <desc id="desc">A green square tile with a bold white W set in the same font stack as the Wirdle header.</desc>
+  <defs>
+    <linearGradient id="tile" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#79b86f"/>
+      <stop offset="1" stop-color="#4f9a4b"/>
+    </linearGradient>
+    <filter id="soft-shadow" x="-10%" y="-10%" width="120%" height="120%">
+      <feDropShadow dx="0" dy="2" stdDeviation="4" flood-color="#2f612e" flood-opacity="0.22"/>
+    </filter>
+  </defs>
+  <rect x="10" y="10" width="236" height="236" fill="url(#tile)"/>
+  <text
+    x="128"
+    y="176"
+    fill="#fff"
+    filter="url(#soft-shadow)"
+    font-family="Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif"
+    font-size="150"
+    font-weight="800"
+    text-anchor="middle"
+  >W</text>
+</svg>

--- a/wirdle/tests/core.rs
+++ b/wirdle/tests/core.rs
@@ -777,6 +777,16 @@ fn serves_static_ui_as_html() {
 }
 
 #[test]
+fn serves_wirdle_icon_as_svg() {
+    let (status, content_type, response) =
+        handle_http_request("GET /wirdle-icon.svg HTTP/1.1\r\n\r\n", &fixture_solver());
+
+    assert_eq!(status, "200 OK");
+    assert_eq!(content_type, "image/svg+xml");
+    assert!(response.contains("Wirdle icon"));
+}
+
+#[test]
 fn health_includes_historical_solution_dates() {
     let past = PastSolutionIndex::load("wordle-data/past_solutions.json").unwrap();
     let (first_date, latest_date) = past.date_range().unwrap();


### PR DESCRIPTION
### Motivation
- Provide a branded SVG icon for the app so the UI can show a favicon and a compact header icon.
- Expose the icon over HTTP so the static UI can reference it at a stable path.
- Update the header to include the icon for stronger branding and accessibility.

### Description
- Add a new static asset `static/wirdle-icon.svg` containing the app icon SVG.
- Extend `handle_http_request` in `wirdle/src/server.rs` to return the icon for `GET /wirdle-icon.svg` with `image/svg+xml` content type using `include_str!`.
- Update `static/index.html` to include a `<link rel="icon" href="/wirdle-icon.svg">` and replace the plain title with a branded `<h1>` that embeds the icon image, plus related CSS for `.brand` and `.brand-icon`.
- Add a unit test `serves_wirdle_icon_as_svg` in `wirdle/tests/core.rs` that verifies the icon endpoint returns `200 OK`, `image/svg+xml`, and contains the SVG title.

### Testing
- Ran the unit test suite with `cargo test`, which included the new `serves_wirdle_icon_as_svg` test and completed successfully.
- Existing HTTP-related tests in `wirdle/tests/core.rs` were executed and continued to pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a42bfcd22008322b36c4fcb034a9256)